### PR TITLE
feat: implemented new sign in screen

### DIFF
--- a/cmd/wallet-web/src/assets/img/onboarding-bg-sm.svg
+++ b/cmd/wallet-web/src/assets/img/onboarding-bg-sm.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe46e3d4399d5573b4ae0849b8ee06a8008c810486d86c0c358becf489bf2f61
+size 967

--- a/cmd/wallet-web/src/components/Spinner/Spinner.vue
+++ b/cmd/wallet-web/src/components/Spinner/Spinner.vue
@@ -1,0 +1,20 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+<template>
+    <svg v-bind="$attrs" class="animate-spin h-8 w-8 text-neutrals-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+    </svg>
+</template>
+
+<script>
+export default {
+    inheritAttrs: false,
+    name: "spinner",
+    methods: {}
+}
+</script>

--- a/cmd/wallet-web/src/pages/Signin.vue
+++ b/cmd/wallet-web/src/pages/Signin.vue
@@ -6,74 +6,44 @@ SPDX-License-Identifier: Apache-2.0
 
 <template>
 	<div
-		class="flex flex-col justify-between items-center min-w-screen min-h-screen bg-scroll bg-no-repeat bg-neutrals-softWhite bg-onboarding-sm md:bg-onboarding px-6"
+		class="flex flex-col justify-between items-center min-w-screen min-h-screen
+              bg-scroll bg-no-repeat bg-neutrals-softWhite bg-onboarding-sm md:bg-onboarding px-6"
 	>
 		<div class="flex flex-grow flex-col justify-center items-center">
+			<!--Trustbloc Sign-up provider div -->
 			<div
-				class="h-auto md:max-w-4xl bg-gradient-dark rounded-xl overflow-hidden text-xl mt-20 md:text-3xl"
+				class="flex flex-col justify-start items-center h-auto w-full sm:w-screen max-w-xl bg-gradient-dark rounded-xl overflow-hidden text-xl mx-6 px-6 mt-20 md:text-3xl"
 			>
-				<!--Trustbloc Intro div  -->
-				<div
-					class="grid md:grid-cols-2 grid-cols-1 bg-no-repeat bg-flare w-full h-full divide-x divide-neutrals-medium divide-opacity-25 md:px-20"
-				>
-					<div class="col-span-1 hidden md:block py-24 pr-16">
-						<Logo class="mb-12" href="" />
-
-						<div class="flex-1 flex items-center overflow-y-auto max-w-full mb-8">
-							<img class="flex w-10 h-10" src="@/assets/img/onboarding-icon-1.svg" />
-							<span class="text-base pl-5 text-neutrals-white align-middle">
-								Keep your digital identity safe
-							</span>
-						</div>
-
-						<div class="flex-1 flex items-center overflow-y-auto max-w-full mb-8">
-							<img class="flex w-10 h-10" src="@/assets/img/onboarding-icon-2.svg" />
-							<span class="text-base pl-5 text-neutrals-white align-middle">
-								Store digital IDs, certifications, and more—all in one secure wallet
-							</span>
-						</div>
-
-						<div class="flex-1 flex items-center overflow-y-auto max-w-full">
-							<img class="flex w-10 h-10" src="@/assets/img/onboarding-icon-3.svg" />
-							<span class="text-base pl-5 text-neutrals-white align-middle">
-								Verify your identity in person or online
-							</span>
-						</div>
-					</div>
-					<!--Trustbloc Sign-up provider div -->
-					<div class="col-span-1 md:block object-none object-center">
-						<div class="px-6 md:pt-16 md:pb-12 md:pl-16 md:pr-0">
-							<Logo class="md:hidden justify-center mt-12 my-2" href="" />
-							<div class="text-center items-center mb-10">
-								<h1 class="text-2xl md:text-4xl font-bold text-neutrals-white">
-									Sign up. It's free!
-								</h1>
-							</div>
-							<div class="flex justify-center content-center w-full py-24 min-h-xl">
-								<Spinner v-if="loading" />
-								<button
-									v-else
-									v-for="(provider, index) in providers"
-									:key="index"
-									class="w-full h-11 max-w-xs flex flex-wrap items-center text-sm font-bold text-neutrals-dark py-2 px-4 mb-4
-                                    bg-neutrals-softWhite rounded-md"
-									@click="beginOIDCLogin(provider.id)"
-								>
-									<img class="object-contain inline-block max-h-6 mr-2" :src="provider.logoURL" />
-									<span class="flex flex-wrap">{{ provider.signUpText }}</span>
-								</button>
-							</div>
-							<div class="text-center py-10 md:pb-0 md:pt-12">
-								<p class="text-base font-normal text-neutrals-white">
-									Already have an account?
-									<a class="text-primary-blue whitespace-nowrap" href="/Signin">Sign in</a>
-								</p>
-							</div>
-						</div>
-					</div>
+				<!-- TODO: add href url to the root component once it is implemented -->
+				<Logo class="py-12" href="" />
+				<div class="text-center items-center mb-10 md:mb-8">
+					<span class="text-2xl md:text-4xl font-bold text-neutrals-white">
+						Sign in to your account
+					</span>
+				</div>
+				<div class="flex justify-center content-center w-full py-24 min-h-xl">
+					<Spinner v-if="loading" />
+					<button
+						v-else
+						v-for="(provider, index) in providers"
+						:key="index"
+						class="w-full h-11 max-w-xs flex flex-wrap items-center text-sm font-bold text-neutrals-dark py-2 px-4 mb-4
+						bg-neutrals-softWhite rounded-md"
+						@click="beginOIDCLogin(provider.id)"
+					>
+						<img class="object-contain inline-block max-h-6 mr-2" :src="provider.logoURL" />
+						<span class="flex flex-wrap">{{ provider.signInText }}</span>
+					</button>
+				</div>
+				<div class="text-center py-10 md:py-12">
+					<p class="text-base font-normal text-neutrals-softWhite">
+						Don't have an account?
+						<a class="text-primary-blue whitespace-nowrap" href="/Signup">Sign up</a>
+					</p>
 				</div>
 			</div>
 		</div>
+		<!-- Foooter -->
 		<ContentFooter />
 	</div>
 </template>
@@ -88,6 +58,20 @@ import { mapActions, mapGetters } from 'vuex';
 import axios from 'axios';
 
 export default {
+	components: {
+		ContentFooter,
+		Logo,
+		Spinner,
+	},
+	data() {
+		return {
+			providers: [],
+			hubOauthProvider: this.hubURL(),
+			statusMsg: '',
+			loading: true,
+			registered: false,
+		};
+	},
 	created: async function() {
 		await this.fetchProviders();
 		//TODO: issue-601 Implement cookie logic with information from the backend.
@@ -117,20 +101,6 @@ export default {
 			this.registered = true;
 		}
 		this.loading = false;
-	},
-	components: {
-		ContentFooter,
-		Logo,
-		Spinner,
-	},
-	data() {
-		return {
-			providers: [],
-			hubOauthProvider: this.hubURL(),
-			statusMsg: '',
-			loading: true,
-			registered: false,
-		};
 	},
 	methods: {
 		...mapActions({
@@ -207,8 +177,7 @@ export default {
 			this.refreshUserPreference();
 		},
 		handleSuccess() {
-			const route = this.$router.resolve({ name: this.redirect });
-			window.open(route.href, '_top');
+			this.$router.push(this.redirect);
 		},
 	},
 };

--- a/cmd/wallet-web/src/pages/layout/ContentFooter.vue
+++ b/cmd/wallet-web/src/pages/layout/ContentFooter.vue
@@ -5,21 +5,21 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 <template>
-  <div class="fixed bottom-0 mx-auto px-18 mb-4 w-full sm:px-20 xs:px-20 lg:mx-0 xl:mx-0 2xl:mx-0 text-center">
-    <div class="text-neutrals-medium mx-auto 2xl:block xl:block lg:block md:block hidden  text-center">
+  <div class="w-full mx-6 px-15 py-6 text-center">
+    <div class="text-neutrals-medium mx-auto md:block hidden text-center">
        © {{ date }} TrustBloc ･ Privacy Policy ･ Terms of Service  ･
       <select class="py-4" style="background-color: transparent">
-        <option class="text-neutrals-dark block  text-sm"  id="english">English</option>
-        <option class="text-neutrals-medium block  text-sm"  id="french">Français</option>
+        <option class="text-neutrals-dark block text-sm" id="english">English</option>
+        <option class="text-neutrals-medium block text-sm" id="french">Français</option>
       </select>
     </div>
-    <div class="text-neutrals-medium relative 2xl:hidden xl:hidden lg:hidden md:hidden block">
+    <div class="text-neutrals-medium md:hidden block">
       <ul class="list-inside">
-        <li> Privacy Policy ･ Terms of Service</li>
-        <li>© {{ date }} TrustBloc ･
+        <li><span class="whitespace-nowrap">Privacy Policy</span> ･ <span class="whitespace-nowrap">Terms of Service</span></li>
+        <li><span class="whitespace-nowrap">© {{ date }} TrustBloc</span> ･
           <select class="py-4" style="background-color: transparent">
-            <option class="text-neutrals-dark block  text-sm">English</option>
-            <option class="text-neutrals-medium block  text-sm">Français</option>
+            <option class="text-neutrals-dark block text-sm">English</option>
+            <option class="text-neutrals-medium block text-sm">Français</option>
           </select>
         </li>
       </ul>

--- a/cmd/wallet-web/src/router/index.js
+++ b/cmd/wallet-web/src/router/index.js
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 import DashboardLayout from "@/pages/layout/DashboardLayout.vue";
 import Dashboard from "@/pages/Dashboard.vue";
 import Login from "@/pages/Login.vue";
+import Signin from "@/pages/Signin.vue";
 import Signup from "@/pages/Signup.vue";
 import Logout from "@/pages/Logout.vue";
 import StoreInWallet from "@/pages/Store.vue";
@@ -99,6 +100,11 @@ const routes = [
         path: "/login",
         name: "login",
         component: Login
+    },
+    {
+        path: "/signin",
+        name: "signin",
+        component: Signin
     },
     // signUp page as per new designs
     {

--- a/cmd/wallet-web/tailwind.js
+++ b/cmd/wallet-web/tailwind.js
@@ -146,6 +146,7 @@ module.exports = {
         'gradient-pink': theme('gradients.pink'),
         'gradient-purple': theme('gradients.purple'),
         'onboarding': "url('~@/assets/img/onboarding-bg-lg.svg')",
+        'onboarding-sm': "url('~@/assets/img/onboarding-bg-sm.svg')",
         'flare': "url('~@/assets/img/onboarding-flare-lg.png')",
       }),
       height: {
@@ -155,6 +156,9 @@ module.exports = {
       width: {
         lg: '550px',
         xl: '896px',
+      },
+      screens: {
+        'xs': '320px',
       },
     },
   },
@@ -170,6 +174,7 @@ module.exports = {
         'h4': { fontSize: theme('fontSize.6xl'), fontWeight: theme('fontWeight.bold') },
         'h5': { fontSize: theme('fontSize.5xl'), fontWeight: theme('fontWeight.bold') },
         'h6': { fontSize: theme('fontSize.4xl'), fontWeight: theme('fontWeight.bold') },
+        'a': { borderBottom: `2px solid ${theme('colors.primary.blue')}`, paddingBottom: 2 },
       })
     }),
     plugin(function({ addComponents, theme }) {


### PR DESCRIPTION
Related to #835 

Implemented new Sign In page according to [the designs](https://share.goabstract.com/74bf341b-17d6-44a2-bf81-6246608b5d73?collectionLayerId=503aa34c-10e9-4d8b-98de-309e5e9d3407&mode=design). Adjusted Sign Up screen, added new tailwind spinner, adjusted footer and layout.

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/33902374/126243208-31684f4c-8861-40cd-8092-8f0df0c097a6.png">
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/33902374/126243236-ddfab009-2832-43ab-9635-5f95c58db7eb.png">
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/33902374/126243270-2a26bc01-3ed9-468d-9e07-311d456613e5.png">
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/33902374/126243291-c6642bc7-05f7-4142-ae9b-135a149a4b13.png">

https://user-images.githubusercontent.com/33902374/126247044-9db77794-22bb-47d6-9f4a-3966f68c79c0.mov

Signed-off-by: Anton Biriukov <anton.biriukov@securekey.com>