### PR TITLE
feat: enhancement in wallet preference updates

### DIFF
--- a/cmd/wallet-web/package-lock.json
+++ b/cmd/wallet-web/package-lock.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "@saeris/vue-spinners": "^1.0.8",
         "@trustbloc-cicd/agent-sdk-web": "^0.1.7-snapshot-6ba149d",
-        "@trustbloc-cicd/wallet-sdk": "^0.1.7-snapshot-6ba149d",
+        "@trustbloc-cicd/wallet-sdk": "^0.1.7-snapshot-534790d",
         "ajv": "^6.12.2",
         "core-js": "^3.4.3",
         "credential-handler-polyfill": "^2.1.0",
@@ -2017,9 +2017,9 @@
       }
     },
     "node_modules/@trustbloc-cicd/wallet-sdk": {
-      "version": "0.1.7-snapshot-6ba149d",
-      "resolved": "https://npm.pkg.github.com/download/@trustbloc-cicd/wallet-sdk/0.1.7-snapshot-6ba149d/7aec528b756f3cbe600120b11c9c2a225dd106bb32d5233b20c2039e762023d3",
-      "integrity": "sha512-YmA/atclJu1g8i/ecQQ8dI9LA0SfIVWBolbUK8qi0f1u4HSkQN6bBXLSF75UpUgnq5IkZMiDRu99AqDFBHQdHg==",
+      "version": "0.1.7-snapshot-534790d",
+      "resolved": "https://npm.pkg.github.com/download/@trustbloc-cicd/wallet-sdk/0.1.7-snapshot-534790d/773cee91ec0a65ec40a85aa831254f2f35ba02d68f07c2ef9c871e59959680cd",
+      "integrity": "sha512-Y4TBg/lEOXM59Ia/VECLn0H9Lk4JuhIVjmD0B5/M16hX3YZ82aasIcy2MHWJ43sDqIImELLXuOwvhcB73c06ZQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.21.1"
@@ -18426,9 +18426,9 @@
       }
     },
     "@trustbloc-cicd/wallet-sdk": {
-      "version": "0.1.7-snapshot-6ba149d",
-      "resolved": "https://npm.pkg.github.com/download/@trustbloc-cicd/wallet-sdk/0.1.7-snapshot-6ba149d/7aec528b756f3cbe600120b11c9c2a225dd106bb32d5233b20c2039e762023d3",
-      "integrity": "sha512-YmA/atclJu1g8i/ecQQ8dI9LA0SfIVWBolbUK8qi0f1u4HSkQN6bBXLSF75UpUgnq5IkZMiDRu99AqDFBHQdHg==",
+      "version": "0.1.7-snapshot-534790d",
+      "resolved": "https://npm.pkg.github.com/download/@trustbloc-cicd/wallet-sdk/0.1.7-snapshot-534790d/773cee91ec0a65ec40a85aa831254f2f35ba02d68f07c2ef9c871e59959680cd",
+      "integrity": "sha512-Y4TBg/lEOXM59Ia/VECLn0H9Lk4JuhIVjmD0B5/M16hX3YZ82aasIcy2MHWJ43sDqIImELLXuOwvhcB73c06ZQ==",
       "requires": {
         "axios": "^0.21.1"
       }

--- a/cmd/wallet-web/package.json
+++ b/cmd/wallet-web/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@saeris/vue-spinners": "^1.0.8",
     "@trustbloc-cicd/agent-sdk-web": "^0.1.7-snapshot-6ba149d",
-    "@trustbloc-cicd/wallet-sdk": "^0.1.7-snapshot-6ba149d",
+    "@trustbloc-cicd/wallet-sdk": "^0.1.7-snapshot-534790d",
     "ajv": "^6.12.2",
     "core-js": "^3.4.3",
     "credential-handler-polyfill": "^2.1.0",

--- a/cmd/wallet-web/src/pages/mixins/common/helper.js
+++ b/cmd/wallet-web/src/pages/mixins/common/helper.js
@@ -77,3 +77,7 @@ export const getCredentialType = (types) => types.filter(type => type != "Verifi
 export const toLower = text => text.toString().toLowerCase()
 
 export const minsToNanoSeconds = ns => ns * 60 * (10 ** 9)
+
+export const getDIDVerificationMethod = (dids, id) => {
+    return jp.query(dids, `$[?(@.id=="${id}")].verificationMethod[*].id`)
+}


### PR DESCRIPTION
- added feature to modify verification method in wallet preferences
- Part of #814

Added Granular control over user preferences like DID, verification method & signature type to use for generating proofs from wallet.

![image](https://user-images.githubusercontent.com/29631944/125979525-c9a6ded8-385f-4d37-af9d-bf5db5dc1000.png)


Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>