### PR TITLE
chore: removed image containing old logo

### DIFF
--- a/cmd/wallet-web/src/assets/img/home_wallet.png
+++ b/cmd/wallet-web/src/assets/img/home_wallet.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e50984ff501d599ffbd6b651efe488282bccbeaa6405106cba1a15b24ddba367
-size 104781

--- a/cmd/wallet-web/src/pages/Login.vue
+++ b/cmd/wallet-web/src/pages/Login.vue
@@ -68,11 +68,6 @@ SPDX-License-Identifier: Apache-2.0
                                 </form>
                             </md-card-content>
                         </div>
-                        <div class="md:px-24 relative">
-                            <div class="hidden md:block">
-                                <img class="object-scale-down h-84 w-full" src="@/assets/img/home_wallet.png" alt="">
-                            </div>
-                        </div>
                     </div>
                 </div>
             </div>

--- a/cmd/wallet-web/src/pages/Signin.vue
+++ b/cmd/wallet-web/src/pages/Signin.vue
@@ -38,7 +38,7 @@ SPDX-License-Identifier: Apache-2.0
 				<div class="text-center py-10 md:py-12">
 					<p class="text-base font-normal text-neutrals-softWhite">
 						Don't have an account?
-						<a class="text-primary-blue whitespace-nowrap" href="/Signup">Sign up</a>
+						<a class="underline-blue text-primary-blue whitespace-nowrap" href="/Signup">Sign up</a>
 					</p>
 				</div>
 			</div>

--- a/cmd/wallet-web/src/pages/Signup.vue
+++ b/cmd/wallet-web/src/pages/Signup.vue
@@ -66,7 +66,7 @@ SPDX-License-Identifier: Apache-2.0
 							<div class="text-center py-10 md:pb-0 md:pt-12">
 								<p class="text-base font-normal text-neutrals-white">
 									Already have an account?
-									<a class="text-primary-blue whitespace-nowrap" href="/Signin">Sign in</a>
+									<a class="underline-blue text-primary-blue whitespace-nowrap" href="/Signin">Sign in</a>
 								</p>
 							</div>
 						</div>

--- a/cmd/wallet-web/tailwind.js
+++ b/cmd/wallet-web/tailwind.js
@@ -174,7 +174,6 @@ module.exports = {
         'h4': { fontSize: theme('fontSize.6xl'), fontWeight: theme('fontWeight.bold') },
         'h5': { fontSize: theme('fontSize.5xl'), fontWeight: theme('fontWeight.bold') },
         'h6': { fontSize: theme('fontSize.4xl'), fontWeight: theme('fontWeight.bold') },
-        'a': { borderBottom: `2px solid ${theme('colors.primary.blue')}`, paddingBottom: 2 },
       })
     }),
     plugin(function({ addComponents, theme }) {
@@ -269,7 +268,7 @@ module.exports = {
           color: theme('colors.neutrals.white'),
           fontSize: theme('fontSize.base'),
           fontWeight: theme('fontWeight.bold'),
-        }
+        },
       }
 
       const inputs = {
@@ -356,11 +355,17 @@ module.exports = {
             top: 18,
             right: theme('spacing.3'),
           },
-        },
-        
+        }
       }
 
-      addComponents({ ...buttons, ...inputs })
+      const links = {
+        '.underline-blue': {
+          borderBottom: `2px solid ${theme('colors.primary.blue')}`,
+          paddingBottom: 2,
+        },
+      }
+
+      addComponents({ ...buttons, ...inputs, ...links })
     }),
   ],
 }


### PR DESCRIPTION
Fixes #861

Removed the image containing the old logo. This page will be switched with the new Sign in page.

<img width="1175" alt="image" src="https://user-images.githubusercontent.com/33902374/126341144-ea4f56d9-a5ae-4ae4-9830-9a29f6ea5df4.png">

Signed-off-by: Anton Biriukov <anton.biriukov@securekey.com>