### PR TITLE
fix: sign-up remove window open line

### DIFF
--- a/cmd/wallet-web/src/pages/Signup.vue
+++ b/cmd/wallet-web/src/pages/Signup.vue
@@ -181,8 +181,7 @@ export default {
 			this.refreshUserPreference();
 		},
 		handleSuccess() {
-			const route = this.$router.resolve({ name: this.redirect });
-			window.open(route.href, '_top');
+      this.$router.push(this.redirect);
 		},
 	},
 };


### PR DESCRIPTION
Aries agent init aborted due to window open command. Logic needs to be revisited during sign-up pop-up feat implementation

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>