### PR TITLE
feat: Add reusable Toast Component 

### DIFF
--- a/cmd/wallet-web/src/assets/img/close-icon.svg
+++ b/cmd/wallet-web/src/assets/img/close-icon.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff8a0a49970bbbee0d2a3a49e1bc36e3ae1b573498a6ebb124ea7ea76323a34e
+size 220

--- a/cmd/wallet-web/src/assets/img/triangle-exclamation.svg
+++ b/cmd/wallet-web/src/assets/img/triangle-exclamation.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f643742b250c9b7d186c887e44de5a3884f06b3acfc77ae4740aa57c3f276a6
+size 387

--- a/cmd/wallet-web/src/components/ToastNotification/ToastNotification.vue
+++ b/cmd/wallet-web/src/components/ToastNotification/ToastNotification.vue
@@ -1,0 +1,45 @@
+<template>
+  <div v-show="close" :class="classname">
+    <div class="xs:flex-none px-4">
+      <img class="sm:w-10 h-6 sm:h-8 w-7" :src="icon" />
+    </div>
+    <div class="flex-col">
+      <span class="text-sm xs:text-lg font-bold leading-relaxed align-left">{{ title }}</span>
+      <div>
+        <span class="text-xs xs:text-sm leading-6 align-left">{{ description }}</span>
+      </div>
+    </div>
+    <div class="xs:flex-none px-4 align-middle">
+      <button type="button" @click="close = !close">
+        <img class="w-6 h-6" src="@/assets/img/close-icon.svg" />
+      </button>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ToastNotification',
+  props: {
+    title: String,
+    description: String,
+    type: String,
+  },
+  data() {
+    return {
+      classname: '',
+      icon: '',
+      close: true,
+    };
+  },
+  created: function () {
+    // Currently, only one type of toast message are supported i.e error, we can easily expand warning, success toast alerts as required etc.
+    switch (this.type) {
+      case 'error':
+        this.classname = 'error-notification';
+        this.icon = require('@/assets/img/triangle-exclamation.svg');
+        break;
+    }
+  },
+};
+</script>

--- a/cmd/wallet-web/src/main.js
+++ b/cmd/wallet-web/src/main.js
@@ -33,6 +33,10 @@ Vue.use(SideBar);
 Vue.use(VueCookies);
 Vue.$cookies.config('7d');
 Vue.use(VueMaterial);
+Vue.component(
+  'ToastNotification',
+  require('./components/ToastNotification/ToastNotification').default
+);
 
 // Returns locale configuration. By default, try VUE_APP_I18N_LOCALE. As fallback, use 'en'.
 function getMappedLocale(locale = process.env.VUE_APP_I18N_LOCALE || 'en') {

--- a/cmd/wallet-web/src/translations/en.json
+++ b/cmd/wallet-web/src/translations/en.json
@@ -19,6 +19,10 @@
       "span1": "Keep your digital identity safe",
       "span2": "Store digital IDs, certifications, and more—all in one secure wallet",
       "span3": "Verify your identity in person or online"
+    },
+    "errorToast": {
+      "title": "Unable to create Account",
+      "description": "Sorry, something went wrong. Please try again or choose a different sign-up partner."
     }
   }
 }

--- a/cmd/wallet-web/src/translations/fr.json
+++ b/cmd/wallet-web/src/translations/fr.json
@@ -19,6 +19,10 @@
       "span1": "Protégez votre identité numérique",
       "span2": "Conservez vos pièces d’identité numériques, vos certifications et bien plus dans un même portefeuille sécurisé",
       "span3": "Vérifiez votre identité en personne ou en ligne"
+    },
+    "errorToast": {
+      "title": "Impossible de créer un compte",
+      "description": "Désolé, un problème est survenu. Veuillez réessayer ou choisir un autre partenaire d’inscription."
     }
   }
 }

--- a/cmd/wallet-web/tailwind.js
+++ b/cmd/wallet-web/tailwind.js
@@ -388,7 +388,25 @@ module.exports = {
         },
       };
 
-      addComponents({ ...buttons, ...inputs, ...links });
+      const toastNotifications = {
+        '.error-notification': {
+          backgroundColor: theme('colors.primary.valencia'),
+          top: theme('spacing.8'),
+          position: 'absolute',
+          borderRadius: theme('spacing.3'),
+          zIndex: 10,
+          maxWidth: '48rem',
+          display: 'flex',
+          verticalAlign: 'middle',
+          flexDirection: 'row',
+          justifyContent: 'flex-start',
+          alignItems: 'center',
+          padding: `${theme('spacing.4')} ${theme('spacing.5')}`,
+          color: theme('colors.neutrals.softWhite'),
+        },
+      };
+
+      addComponents({ ...buttons, ...inputs, ...links, ...toastNotifications });
     }),
   ],
 };


### PR DESCRIPTION
closes #768
Alert can be used in this style anywhere in the wallet vue component`<toast-notification
        :title="i18n.Signup.errorToast.title"
        :description="i18n.Signup.errorToast.description"
        type="error"></toast-notification>`

Integration will be done in #898 
This is the custom resusable toast component, which can be used anywhere in the wallet in the following style.  We are only supporting error type. 

<img width="1029" alt="Screen Shot 2021-08-05 at 9 59 05 PM" src="https://user-images.githubusercontent.com/7862595/128445198-b359f0e0-40ed-4c14-9916-bfd6d90cafa3.png">
<img width="1680" alt="Screen Shot 2021-08-05 at 10 01 28 PM" src="https://user-images.githubusercontent.com/7862595/128445152-d424603c-b081-4851-bb95-1506bab3b7d7.png">

<img width="1679" alt="Screen Shot 2021-08-05 at 10 01 18 PM" src="https://user-images.githubusercontent.com/7862595/128445146-6072762a-85a0-41c0-946a-873beec6f38f.png">



Signed-off-by: talwinder kaur <talwinder.kaur@securekey.com>