### PR TITLE
feat: Integrate toast notification for system failures and remove loader on closed popup

### DIFF
--- a/cmd/wallet-web/src/pages/LoginHandle.vue
+++ b/cmd/wallet-web/src/pages/LoginHandle.vue
@@ -27,11 +27,13 @@ export default {
       window.top.close();
     } else {
       window.location.href = this.serverURL() + '/oidc/login?provider=' + this.provider;
+      window.addEventListener('beforeunload', this.onclose);
     }
   },
   methods: {
     ...mapActions({
       updateUserOnboard: 'updateUserOnboard',
+      updateLoginSuspended: 'updateLoginSuspended',
     }),
     ...mapGetters(['serverURL']),
     checkIfUserLoggedIn: async function () {
@@ -39,6 +41,9 @@ export default {
         method: 'GET',
         credentials: 'include',
       });
+    },
+    onclose: function onclose() {
+      this.updateLoginSuspended();
     },
   },
 };

--- a/cmd/wallet-web/src/store/index.js
+++ b/cmd/wallet-web/src/store/index.js
@@ -20,5 +20,5 @@ Vue.use(Vuex);
 
 export default new Vuex.Store({
   modules: { connections, mode, mediator, credentials, presentation, user, options, locale },
-  plugins: [sharedMutations({ predicate: ['setUserLoggedIn', 'setLocale'] })],
+  plugins: [sharedMutations({ predicate: ['setUserLoggedIn', 'setLocale', 'setLogInSuspended'] })],
 });

--- a/cmd/wallet-web/src/store/modules/user.js
+++ b/cmd/wallet-web/src/store/modules/user.js
@@ -14,6 +14,7 @@ export default {
     setupStatus: null,
     profile: null,
     loggedIn: false,
+    logInSuspended: false,
   },
   mutations: {
     setUser(state, val) {
@@ -50,6 +51,9 @@ export default {
     },
     setUserLoggedIn(state) {
       state.loggedIn = true;
+    },
+    setLogInSuspended(state) {
+      state.logInSuspended = true;
     },
   },
   actions: {
@@ -113,6 +117,9 @@ export default {
     updateUserOnboard({ commit }) {
       commit('setUserLoggedIn');
     },
+    updateLoginSuspended({ commit }) {
+      commit('setLogInSuspended');
+    },
   },
   getters: {
     getCurrentUser(state) {
@@ -127,6 +134,9 @@ export default {
     },
     isUserLoggedIn(state) {
       return state.loggedIn;
+    },
+    isLoginSuspended(state) {
+      return state.logInSuspended;
     },
   },
   modules: {

--- a/cmd/wallet-web/src/translations/en.json
+++ b/cmd/wallet-web/src/translations/en.json
@@ -9,7 +9,11 @@
   "Signin": {
     "heading": "Sign in to your account",
     "redirect": "Don't have an account?",
-    "signup": "Sign up"
+    "signup": "Sign up",
+    "errorToast": {
+      "title": "Unable to create Account",
+      "description": "Sorry, something went wrong. Please try again or choose a different sign-up partner."
+    }
   },
   "Signup": {
     "heading": "Sign up. It's free!",

--- a/cmd/wallet-web/src/translations/fr.json
+++ b/cmd/wallet-web/src/translations/fr.json
@@ -9,7 +9,11 @@
   "Signin": {
     "heading": "Connectez-vous à votre compte",
     "redirect": "Vous n’avez pas de compte?",
-    "signup": "S’inscrire"
+    "signup": "S’inscrire",
+    "errorToast": {
+      "title": "Impossible de créer un compte",
+      "description": "Désolé, un problème est survenu. Veuillez réessayer ou choisir un autre partenaire d’inscription."
+    }
   },
   "Signup": {
     "heading": "Inscrivez-vous. C’est gratuit!",


### PR DESCRIPTION
The toast notification is tested with adding wrong param in option.js file to simulate system failure. 

One existing issue. Pop up it self removes the loader if user closes the window while its redirecting, but when its redirected, the third party then loader dont get removed. I havent found a way where window.listener can unload from window.location.href.  Issue #914 is created for that

https://user-images.githubusercontent.com/7862595/128655697-8331f83c-6dab-4cf3-ac6c-59d2c026ff80.mov




closes #899 
closes #898

Signed-off-by: talwinder kaur <talwinder.kaur@securekey.com>