### PR TITLE
fix: Credential detail on refresh fails to get processed credential and render base64 image

### DIFF
--- a/cmd/wallet-web/src/config/credentialDisplayData.js
+++ b/cmd/wallet-web/src/config/credentialDisplayData.js
@@ -7,9 +7,23 @@ export default {
   PermanentResidentCard: {
     id: ['$.id'],
     properties: {
-      birthCountry: {
-        path: ['$.credentialSubject.birthCountry'],
-        label: 'Country of Birth',
+      image: {
+        path: ['$.credentialSubject.image'],
+        label: 'Photo',
+        type: 'image',
+        format: '',
+      },
+      givenName: {
+        path: ['$.credentialSubject.givenName'],
+        label: 'Given Name',
+      },
+      familyName: {
+        path: ['$.credentialSubject.familyName'],
+        label: 'Family Name',
+      },
+      gender: {
+        path: ['$.credentialSubject.gender'],
+        label: 'Gender',
       },
       birthDate: {
         path: ['$.credentialSubject.birthDate'],
@@ -17,25 +31,15 @@ export default {
         type: 'date',
         format: 'yyyy-mm-dd',
       },
-      familyName: {
-        path: ['$.credentialSubject.familyName'],
-        label: 'Family Name',
-      },
-      givenName: {
-        path: ['$.credentialSubject.givenName'],
-        label: 'Given Name',
+      birthCountry: {
+        path: ['$.credentialSubject.birthCountry'],
+        label: 'Country of Birth',
       },
       residentSince: {
         path: ['$.credentialSubject.residentSince'],
         label: 'Resident Since',
         type: 'date',
         format: 'yyyy-mm-dd',
-      },
-      image: {
-        path: ['$.credentialSubject.image'],
-        label: 'Photo',
-        type: 'image',
-        format: '',
       },
     },
     icon: 'credential--generic-icon.svg',
@@ -69,6 +73,24 @@ export default {
   VaccinationCertificate: {
     id: ['$.id'],
     properties: {
+      RecipientFamilyName: {
+        path: ['$.credentialSubject.recipient.familyName'],
+        label: 'Family Name',
+      },
+      RecipientGivenName: {
+        path: ['$.credentialSubject.recipient.givenName'],
+        label: 'Given Name',
+      },
+      RecipientGender: {
+        path: ['$.credentialSubject.recipient.gender'],
+        label: 'Gender',
+      },
+      RecipientBirthDate: {
+        path: ['$.credentialSubject.recipient.birthDate'],
+        label: 'Date of Birth',
+        type: 'date',
+        format: 'yyyy-mm-dd',
+      },
       administeringCentre: {
         path: ['$.credentialSubject.administeringCentre'],
         label: 'Administering Centre',
@@ -88,24 +110,6 @@ export default {
       healthProfessional: {
         path: ['$.credentialSubject.healthProfessional'],
         label: 'Health Professional',
-      },
-      RecipientBirthDate: {
-        path: ['$.credentialSubject.recipient.birthDate'],
-        label: 'Date of Birth',
-        type: 'date',
-        format: 'yyyy-mm-dd',
-      },
-      RecipientFamilyName: {
-        path: ['$.credentialSubject.recipient.familyName'],
-        label: 'Family Name',
-      },
-      RecipientGender: {
-        path: ['$.credentialSubject.recipient.gender'],
-        label: 'Gender',
-      },
-      RecipientGivenName: {
-        path: ['$.credentialSubject.recipient.givenName'],
-        label: 'Given Name',
       },
       VaccineCode: {
         path: ['$.credentialSubject.vaccine.atcCode'],

--- a/cmd/wallet-web/src/pages/CredentialDetails.vue
+++ b/cmd/wallet-web/src/pages/CredentialDetails.vue
@@ -30,9 +30,14 @@
         >
           <!-- Todo: Add the dropdown for the nested credentials 1016-->
           <td class="py-4 pr-6 pl-3 text-neutrals-medium">{{ property.label }}</td>
-          <!-- Todo: Convert the image type string of base 64 to an image 1032-->
           <td v-if="property.type != 'image'" class="py-4 pr-6 pl-3 text-neutrals-dark break-words">
             {{ property.value }}
+          </td>
+          <td
+            v-if="property.type === 'image'"
+            class="py-4 pr-6 pl-3 text-neutrals-dark break-words"
+          >
+            <img :src="property.value" class="w-20 h-20" />
           </td>
         </tr>
       </table>
@@ -51,21 +56,14 @@ export default {
     Banner,
     FlyoutMenu,
   },
-  data() {
-    return {
-      credential: {},
-      credentialID: '',
-    };
-  },
   computed: {
     i18n() {
       return this.$t('CredentialDetails');
     },
     ...mapGetters(['getProcessedCredentialByID']),
-  },
-  created() {
-    this.credentialID = this.$route.params.id;
-    this.credential = this.getProcessedCredentialByID(this.credentialID);
+    credential() {
+      return this.getProcessedCredentialByID(this.$route.params.id);
+    },
   },
 };
 </script>

--- a/cmd/wallet-web/src/store/modules/user.js
+++ b/cmd/wallet-web/src/store/modules/user.js
@@ -147,8 +147,10 @@ export default {
     isLoginSuspended(state) {
       return state.logInSuspended;
     },
-    getProcessedCredentialByID: (state) => (id) =>
-      state.processedCredentials.find((credential) => credential.id === id),
+    getProcessedCredentialByID: (state) => (id) => {
+      state.processedCredentials = JSON.parse(localStorage.getItem('processedCredentials'));
+      return state.processedCredentials.find((credential) => credential.id === id);
+    },
   },
   modules: {
     agent: {


### PR DESCRIPTION
closes #1035  #1032 

1. On page refresh now the credential detail screen works as well. 
2 If the type is image it will render as image otherwise just simple value. 
3. Rearranged the credential detail config in the sequence to display

<img width="1677" alt="Screen Shot 2021-09-06 at 4 49 56 PM" src="https://user-images.githubusercontent.com/7862595/132260000-10134a61-6a45-4353-9266-6ce7e9264178.png">

https://user-images.githubusercontent.com/7862595/132260060-921319b7-adfe-47e6-892e-6f1035b3b471.mov



Signed-off-by: talwinder50 <talwinderkaur50@gmail.com>