### PR TITLE
chore: set agent-sdk and wallet-sdk to fixed version

### DIFF
--- a/cmd/wallet-web/package-lock.json
+++ b/cmd/wallet-web/package-lock.json
@@ -8,8 +8,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@saeris/vue-spinners": "^1.0.8",
-        "@trustbloc-cicd/agent-sdk-web": "^0.1.7-snapshot-59a84a9",
-        "@trustbloc-cicd/wallet-sdk": "^0.1.7-snapshot-59a84a9",
+        "@trustbloc-cicd/agent-sdk-web": "0.1.7-snapshot-59a84a9",
+        "@trustbloc-cicd/wallet-sdk": "0.1.7-snapshot-59a84a9",
         "ajv": "^8.6.2",
         "base64url": "^3.0.1",
         "core-js": "^3.16.1",
@@ -1932,17 +1932,14 @@
       "dev": true
     },
     "node_modules/@trustbloc-cicd/agent-sdk-web": {
-      "version": "0.1.7-snapshot-84de477",
-      "resolved": "https://npm.pkg.github.com/download/@trustbloc-cicd/agent-sdk-web/0.1.7-snapshot-84de477/5a1ba0bb6c727f695a430d466d52d09ac3539bf2861afb540baa062418bdf49b",
-      "integrity": "sha512-U4i7x2AjlR+8NWZDSPiKMYFbiK38vHtOkFGnWhycyK7KC2twc78CPyKZYzGItVIM4mgp3X61X5djXkac8CO3IA==",
+      "version": "0.1.7-snapshot-59a84a9",
+      "resolved": "https://npm.pkg.github.com/download/@trustbloc-cicd/agent-sdk-web/0.1.7-snapshot-59a84a9/59da7911a675ad355f1027de4ae59b256895badc49e39f75bbc32d8012b27bca",
+      "integrity": "sha512-qhpm5sYAwNqe4TfKOmeo3bbBXheJr7sLyudMXPqxL97fcX6/8wQgGNuPR731yTws3/wftoFyKRiBELziKj9wqQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "axios": "0.20.0",
         "generate-export-aliases": "^1.1.0",
         "minimist": "^1.2.5"
-      },
-      "engines": {
-        "node": ">=12.13",
-        "npm": ">=6.13"
       }
     },
     "node_modules/@trustbloc-cicd/agent-sdk-web/node_modules/axios": {
@@ -1954,9 +1951,10 @@
       }
     },
     "node_modules/@trustbloc-cicd/wallet-sdk": {
-      "version": "0.1.7-snapshot-84de477",
-      "resolved": "https://npm.pkg.github.com/download/@trustbloc-cicd/wallet-sdk/0.1.7-snapshot-84de477/a5a4ce2e71926f053aa3af365acdbba7ad4f56c0ce4c57795892976dc5ff606d",
-      "integrity": "sha512-At/ZVf8DW+I/prCJMbA/nIIqRKfQDZ3xTATIV33SUaHw3UARv1v60mKhwx5YkMHEeUJxWl9184qQ+W3H3cXCBw==",
+      "version": "0.1.7-snapshot-59a84a9",
+      "resolved": "https://npm.pkg.github.com/download/@trustbloc-cicd/wallet-sdk/0.1.7-snapshot-59a84a9/a19c5eb33b09b7929a5d4fde067f973df95bddb4a9865c6b6a24be9e7ff456e2",
+      "integrity": "sha512-dARQBQ2xhCGQOXLa4YZcZ66kTnAsyHvnkWaehCY25voS8n5NTCnqE+mK1XcM/MIbaQvmFGkgjoBXGqv/ZFuJ8w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.21.1"
       }
@@ -23367,9 +23365,9 @@
       "dev": true
     },
     "@trustbloc-cicd/agent-sdk-web": {
-      "version": "0.1.7-snapshot-84de477",
-      "resolved": "https://npm.pkg.github.com/download/@trustbloc-cicd/agent-sdk-web/0.1.7-snapshot-84de477/5a1ba0bb6c727f695a430d466d52d09ac3539bf2861afb540baa062418bdf49b",
-      "integrity": "sha512-U4i7x2AjlR+8NWZDSPiKMYFbiK38vHtOkFGnWhycyK7KC2twc78CPyKZYzGItVIM4mgp3X61X5djXkac8CO3IA==",
+      "version": "0.1.7-snapshot-59a84a9",
+      "resolved": "https://npm.pkg.github.com/download/@trustbloc-cicd/agent-sdk-web/0.1.7-snapshot-59a84a9/59da7911a675ad355f1027de4ae59b256895badc49e39f75bbc32d8012b27bca",
+      "integrity": "sha512-qhpm5sYAwNqe4TfKOmeo3bbBXheJr7sLyudMXPqxL97fcX6/8wQgGNuPR731yTws3/wftoFyKRiBELziKj9wqQ==",
       "requires": {
         "axios": "0.20.0",
         "generate-export-aliases": "^1.1.0",
@@ -23387,9 +23385,9 @@
       }
     },
     "@trustbloc-cicd/wallet-sdk": {
-      "version": "0.1.7-snapshot-84de477",
-      "resolved": "https://npm.pkg.github.com/download/@trustbloc-cicd/wallet-sdk/0.1.7-snapshot-84de477/a5a4ce2e71926f053aa3af365acdbba7ad4f56c0ce4c57795892976dc5ff606d",
-      "integrity": "sha512-At/ZVf8DW+I/prCJMbA/nIIqRKfQDZ3xTATIV33SUaHw3UARv1v60mKhwx5YkMHEeUJxWl9184qQ+W3H3cXCBw==",
+      "version": "0.1.7-snapshot-59a84a9",
+      "resolved": "https://npm.pkg.github.com/download/@trustbloc-cicd/wallet-sdk/0.1.7-snapshot-59a84a9/a19c5eb33b09b7929a5d4fde067f973df95bddb4a9865c6b6a24be9e7ff456e2",
+      "integrity": "sha512-dARQBQ2xhCGQOXLa4YZcZ66kTnAsyHvnkWaehCY25voS8n5NTCnqE+mK1XcM/MIbaQvmFGkgjoBXGqv/ZFuJ8w==",
       "requires": {
         "axios": "^0.21.1"
       }

--- a/cmd/wallet-web/package.json
+++ b/cmd/wallet-web/package.json
@@ -17,8 +17,8 @@
   },
   "dependencies": {
     "@saeris/vue-spinners": "^1.0.8",
-    "@trustbloc-cicd/agent-sdk-web": "^0.1.7-snapshot-59a84a9",
-    "@trustbloc-cicd/wallet-sdk": "^0.1.7-snapshot-59a84a9",
+    "@trustbloc-cicd/agent-sdk-web": "0.1.7-snapshot-59a84a9",
+    "@trustbloc-cicd/wallet-sdk": "0.1.7-snapshot-59a84a9",
     "ajv": "^8.6.2",
     "base64url": "^3.0.1",
     "core-js": "^3.16.1",


### PR DESCRIPTION
Since, there are code breaking changes in agent-sdk, we need to set their version to a fixed snapshot/release

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>