### PR TITLE
fix: disable error display for DIDAuth query failure

### DIFF
--- a/cmd/wallet-web/src/pages/DIDAuth.vue
+++ b/cmd/wallet-web/src/pages/DIDAuth.vue
@@ -121,7 +121,8 @@ export default {
       this.presentation = results[0];
     } catch (e) {
       console.error('failed to prepare DIDAuth response:', e);
-      this.errors.push('failed to handle request, try again later.');
+      // TODO https://github.com/trustbloc/wallet/issues/1067 DIDAuth query failure
+      // this.errors.push('failed to handle request, try again later.');
       this.loading = false;
     }
 


### PR DESCRIPTION
This is a temp solution and the root cause will be tracked as part of https://github.com/trustbloc/wallet/issues/1067.

closes #1066 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>