### PR TITLE
feat: added on key enter even handler for some ui elements

### DIFF
--- a/cmd/wallet-web/src/components/Navbar/NavbarLink.vue
+++ b/cmd/wallet-web/src/components/Navbar/NavbarLink.vue
@@ -28,6 +28,7 @@
       class="flex flex-row justify-start items-center px-10 w-full h-16 cursor-pointer"
       v-bind="$attrs"
       @click="handleClick($attrs)"
+      @keyup.enter="handleClick($attrs)"
     >
       <img v-if="icon" :src="iconUrl" class="w-8 h-8" />
       <div v-else class="w-8 h-8" />

--- a/cmd/wallet-web/src/components/Signout/Signout.vue
+++ b/cmd/wallet-web/src/components/Signout/Signout.vue
@@ -22,7 +22,8 @@
     <button
       class="flex flex-row justify-start items-center px-10 w-full h-16"
       type="button"
-      @click="signout"
+      @click="signout()"
+      @keyup.enter="signout()"
     >
       <img src="@/assets/img/signout.svg" />
       <span class="ml-4 text-lg font-bold text-neutrals-white">{{ i18n.signout }}</span>

--- a/cmd/wallet-web/src/pages/Signin.vue
+++ b/cmd/wallet-web/src/pages/Signin.vue
@@ -43,7 +43,6 @@
           flex flex-col
         "
       >
-        <!-- TODO: add href url to the root component once it is implemented -->
         <Logo class="py-12" />
         <div class="items-center mb-10 md:mb-8 text-center">
           <span class="text-2xl md:text-4xl font-bold text-neutrals-white">
@@ -72,6 +71,7 @@
               flex flex-wrap
             "
             @click="beginOIDCLogin(provider.id)"
+            @keyup.enter="beginOIDCLogin(provider.id)"
           >
             <img class="inline-block object-contain mr-2 max-h-6" :src="provider.logoURL" />
             <span class="flex flex-wrap">{{ provider.signInText }}</span>

--- a/cmd/wallet-web/src/pages/Signup.vue
+++ b/cmd/wallet-web/src/pages/Signup.vue
@@ -101,6 +101,7 @@
                     flex flex-wrap
                   "
                   @click="beginOIDCLogin(provider.id)"
+                  @keyup.enter="beginOIDCLogin(provider.id)"
                 >
                   <img class="inline-block object-contain mr-2 max-h-6" :src="provider.logoURL" />
                   <span id="signUpText" class="flex flex-wrap">{{ provider.signUpText }}</span>


### PR DESCRIPTION
Fixes #1143

This would allow to click on these elements by pressing `enter` key when focused.

Signed-off-by: Anton Biriukov <anton.biriukov@securekey.com>