### PR TITLE
WIP refactor: Refactor flyout menu list and create composable modal component

### DIFF
--- a/cmd/wallet-web/src/EventBus.js
+++ b/cmd/wallet-web/src/EventBus.js
@@ -1,5 +1,3 @@
 import Vue from 'vue';
 
-const EventBus = new Vue();
-
-export default EventBus;
+export const ModalBus = new Vue();

--- a/cmd/wallet-web/src/components/FlyoutMenu/FlyoutMenu.vue
+++ b/cmd/wallet-web/src/components/FlyoutMenu/FlyoutMenu.vue
@@ -16,6 +16,7 @@
         <img src="@/assets/img/icons-sm--chevron-down-icon.svg" />
       </div>
     </button>
+    <!-- TODO: Issue-1193 Refactor outline vault to accomdate both credential and vault flyout" -->
     <button
       v-if="type === 'outline'"
       id="outline"
@@ -31,43 +32,43 @@
         border border-neutrals-chatelle
         hover:border-neutrals-mountainMist-light
       "
-      @mouseover="showTooltip = !showTooltip"
       @focus="showTooltip = !showTooltip"
     >
       <div class="flex-none p-2">
         <img
           id="flyoutMenuId"
           src="@/assets/img/more-icon.svg"
-          @click="showFlyoutMenuList = !showFlyoutMenuList"
+          @click="toggleFlyoutMenuList"
+          @mouseover="showTooltip = !showTooltip"
         />
       </div>
       <div v-if="showTooltip" id="tooltip">
         <tool-tip :tool-tip-label="i18n.toolTipLabel"></tool-tip>
       </div>
     </button>
-    <div v-if="showFlyoutMenuList" id="flyoutMenuList" class="relative">
-      <flyout-menu-list :credential-id="credentialId" />
+    <div
+      v-if="showFlyoutMenuList"
+      id="flyoutMenuList"
+      class="relative"
+      @click.prevent="toggleFlyoutMenuList"
+    >
+      <slot />
     </div>
   </div>
 </template>
 
 <script>
 import ToolTip from '@/components/ToolTip/ToolTip.vue';
-import FlyoutMenuList from '@/components/FlyoutMenu/FlyoutMenuList.vue';
 
 export default {
   name: 'FlyoutMenu',
   components: {
     ToolTip,
-    FlyoutMenuList,
   },
   props: {
     type: {
       type: String,
       default: 'default',
-    },
-    credentialId: {
-      type: String,
     },
   },
   data() {
@@ -83,6 +84,23 @@ export default {
   computed: {
     i18n() {
       return this.$t('CredentialDetails');
+    },
+  },
+  mounted() {
+    document.addEventListener('click', this.close);
+  },
+  beforeDestroy() {
+    document.removeEventListener('click', this.close);
+  },
+  methods: {
+    toggleFlyoutMenuList(e) {
+      this.showFlyoutMenuList = !this.showFlyoutMenuList;
+      this.showTooltip = false;
+    },
+    close(e) {
+      if (!this.$el.contains(e.target)) {
+        this.showFlyoutMenuList = false;
+      }
     },
   },
 };

--- a/cmd/wallet-web/src/components/FlyoutMenu/FlyoutMenuButton.vue
+++ b/cmd/wallet-web/src/components/FlyoutMenu/FlyoutMenuButton.vue
@@ -1,0 +1,37 @@
+<template>
+  <div>
+    <button
+      :id="id"
+      :class="[`block font-bold block pb-2 text-${color}`]"
+      @click="$emit('click', $event)"
+    >
+      {{ text }}
+      <slot />
+    </button>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'FlyoutMenuButton',
+  props: {
+    text: {
+      type: String,
+      required: true,
+    },
+    color: {
+      type: String,
+      default: 'neutrals-medium',
+    },
+    id: {
+      type: String,
+      required: true,
+    },
+  },
+  computed: {
+    i18n() {
+      return this.$t('CredentialDetails');
+    },
+  },
+};
+</script>

--- a/cmd/wallet-web/src/components/FlyoutMenu/FlyoutMenuList.vue
+++ b/cmd/wallet-web/src/components/FlyoutMenu/FlyoutMenuList.vue
@@ -15,144 +15,14 @@
       bg-white
     "
   >
-    <div class="p-4 text-base text-start">
-      <button id="renameCredential" class="block pb-2 font-bold">
-        {{ i18n.renameCredential }}
-      </button>
-      <button id="moveCredential" class="block pb-2 font-bold">{{ i18n.moveCredential }}</button>
-      <button
-        id="deleteCredential"
-        class="block font-bold text-primary-vampire"
-        @click="toggleDeleteCredentialModal()"
-      >
-        {{ i18n.deleteCredential }}
-      </button>
-    </div>
-    <!-- todo move to components folder-->
-    <div
-      v-if="showDeleteCredentialModal"
-      class="flex overflow-y-auto fixed inset-0 z-50 justify-center items-center bg-gradient-harold"
-    >
-      <div class="relative mx-6 lg:mx-auto max-w-6xl bg-neutrals-white rounded-2xl modal-width">
-        <!--content-->
-        <div class="flex relative flex-col items-center px-8 pt-10 w-full">
-          <div class="flex justify-center items-center w-15 h-15 bg-primary-valencia rounded-full">
-            <svg width="32" height="32" xmlns="http://www.w3.org/2000/svg">
-              <g transform="translate(3 6)" fill="none" fill-rule="evenodd">
-                <rect stroke="#ffffff" stroke-width="2" x="1" y="1" width="24" height="19" rx="4" />
-                <ellipse fill="#ffffff" cx="8" cy="13" rx="4" ry="2" />
-                <circle fill="#ffffff" cx="8" cy="8" r="2" />
-                <path
-                  stroke="#ffffff"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M16 8h5M16 13h2"
-                />
-              </g>
-            </svg>
-          </div>
-          <span class="pt-5 pb-3 text-lg font-bold text-neutrals-dark align-center">
-            {{ i18n.deleteCredential }}?
-          </span>
-          <div class="relative flex-auto">
-            <p class="pb-12 text-base text-center text-neutrals-medium lg:text-start">
-              {{ i18n.deleteCredentialConfirmMessage }}
-            </p>
-          </div>
-        </div>
-        <!--footer-->
-        <div
-          class="
-            md:flex-row
-            lg:flex-row
-            gap-4
-            justify-start
-            md:justify-between
-            lg:justify-between
-            items-center
-            px-5
-            md:px-8
-            lg:px-8
-            pt-4
-            pb-5
-            text-center
-            bg-neutrals-magnolia
-            rounded-b-2xl
-            flex flex-col
-            lg:text-start
-            md:text-start
-            border-t border-0 border-neutrals-lilacSoft
-          "
-        >
-          <button
-            class="w-full md:w-auto lg:w-auto btn-outline"
-            type="button"
-            @click="toggleDeleteCredentialModal()"
-          >
-            {{ i18n.deleteButtonCancel }}
-          </button>
-          <button
-            id="deleteButton"
-            class="order-first md:order-last lg:order-last w-full md:w-auto lg:w-auto btn-danger"
-            type="button"
-            @click="deleteCredential(credentialId)"
-          >
-            {{ i18n.deleteButtonLabel }}
-          </button>
-        </div>
-      </div>
-    </div>
+    <ul class="p-4 text-base text-start">
+      <slot />
+    </ul>
   </div>
 </template>
 
 <script>
-import { mapGetters } from 'vuex';
-import { CredentialManager } from '@trustbloc/wallet-sdk';
-import base64url from 'base64url';
-
 export default {
   name: 'FlyoutMenuList',
-  props: {
-    credentialId: {
-      type: String,
-    },
-  },
-  data() {
-    return {
-      showDeleteCredentialModal: false,
-      agent: null,
-    };
-  },
-  computed: {
-    i18n() {
-      return this.$t('CredentialDetails');
-    },
-  },
-  methods: {
-    ...mapGetters('agent', { getAgentInstance: 'getInstance' }),
-    ...mapGetters(['getCurrentUser']),
-    async deleteCredential(credentialID) {
-      let { user, token } = this.getCurrentUser().profile;
-      let credentialManager = new CredentialManager({ agent: this.getAgentInstance(), user });
-      const credID = base64url.decode(credentialID);
-      try {
-        let resp = await credentialManager.remove(token, credID);
-        this.$router.push({ name: 'dashboard' });
-      } catch (e) {
-        console.error('failed to remove credential:', e);
-      }
-    },
-    toggleDeleteCredentialModal() {
-      this.showDeleteCredentialModal = !this.showDeleteCredentialModal;
-    },
-  },
 };
 </script>
-
-<style scoped>
-.modal-width {
-  width: 28rem;
-  box-shadow: 0px 12px 48px 0px rgba(25, 12, 33, 0.2);
-}
-</style>

--- a/cmd/wallet-web/src/components/Modal/Credential/Delete.vue
+++ b/cmd/wallet-web/src/components/Modal/Credential/Delete.vue
@@ -1,0 +1,112 @@
+<template>
+  <div>
+    <!--content-->
+    <div class="flex relative flex-col items-center px-8 pt-10 w-full">
+      <div class="flex justify-center items-center w-15 h-15 bg-primary-valencia rounded-full">
+        <svg width="32" height="32" xmlns="http://www.w3.org/2000/svg">
+          <g transform="translate(3 6)" fill="none" fill-rule="evenodd">
+            <rect stroke="#ffffff" stroke-width="2" x="1" y="1" width="24" height="19" rx="4" />
+            <ellipse fill="#ffffff" cx="8" cy="13" rx="4" ry="2" />
+            <circle fill="#ffffff" cx="8" cy="8" r="2" />
+            <path
+              stroke="#ffffff"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M16 8h5M16 13h2"
+            />
+          </g>
+        </svg>
+      </div>
+      <span class="pt-5 pb-3 text-lg font-bold text-neutrals-dark align-center">
+        {{ i18n.deleteCredential }}?
+      </span>
+      <div class="relative flex-auto">
+        <p class="pb-12 text-base text-center text-neutrals-medium lg:text-start">
+          {{ i18n.deleteCredentialConfirmMessage }}
+        </p>
+      </div>
+    </div>
+    <!--footer-->
+    <div
+      class="
+        md:flex-row
+        lg:flex-row
+        gap-4
+        justify-start
+        md:justify-between
+        lg:justify-between
+        items-center
+        px-5
+        md:px-8
+        lg:px-8
+        pt-4
+        pb-5
+        text-center
+        bg-neutrals-magnolia
+        rounded-b-2xl
+        flex flex-col
+        lg:text-start
+        md:text-start
+        border-t border-0 border-neutrals-lilacSoft
+      "
+    >
+      <button
+        class="w-full md:w-auto lg:w-auto btn-outline"
+        type="button"
+        @click="$emit('onClose')"
+      >
+        {{ i18n.deleteButtonCancel }}
+      </button>
+      <button
+        id="deleteButton"
+        class="order-first md:order-last lg:order-last w-full md:w-auto lg:w-auto btn-danger"
+        type="button"
+        @click="deleteCredential(credentialId)"
+      >
+        {{ i18n.deleteButtonLabel }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex';
+import { CredentialManager } from '@trustbloc-cicd/wallet-sdk';
+import base64url from 'base64url';
+
+export default {
+  name: 'DeleteCredential',
+  props: {
+    credentialId: {
+      type: String,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      agent: null,
+    };
+  },
+  computed: {
+    i18n() {
+      return this.$t('CredentialDetails');
+    },
+  },
+  methods: {
+    ...mapGetters('agent', { getAgentInstance: 'getInstance' }),
+    ...mapGetters(['getCurrentUser']),
+    async deleteCredential(credentialID) {
+      const { user, token } = this.getCurrentUser().profile;
+      const credentialManager = new CredentialManager({ agent: this.getAgentInstance(), user });
+      const credID = base64url.decode(credentialID);
+      try {
+        const resp = await credentialManager.remove(token, credID);
+        this.$router.push({ name: 'dashboard' });
+      } catch (e) {
+        console.error('failed to remove credential:', e);
+      }
+    },
+  },
+};
+</script>

--- a/cmd/wallet-web/src/components/Modal/Modal.vue
+++ b/cmd/wallet-web/src/components/Modal/Modal.vue
@@ -1,0 +1,48 @@
+<template>
+  <Modal :is-open="!!component" :title="title" @onClose="handleModalClose">
+    <component :is="component" v-bind="props" @onClose="handleClose" />
+  </Modal>
+</template>
+
+<script>
+import { ModalBus } from '@/EventBus';
+
+import Modal from './ModalLayout';
+
+export default {
+  components: { Modal },
+  data() {
+    return {
+      component: null,
+      title: '',
+      props: null,
+      closeOnClick: true,
+    };
+  },
+  created() {
+    ModalBus.$on('open', ({ component, title = '', props = null, closeOnClick = true }) => {
+      this.component = component;
+      this.title = title;
+      this.props = props;
+      this.closeOnClick = closeOnClick;
+    });
+    document.addEventListener('keyup', this.handleKeyup);
+  },
+  beforeDestroy() {
+    document.removeEventListener('keyup', this.handleKeyup);
+  },
+  methods: {
+    handleModalClose() {
+      if (!this.closeOnClick) return;
+      this.handleClose();
+    },
+    handleClose() {
+      this.component = null;
+    },
+    handleKeyup(e) {
+      // esc code
+      if (e.keyCode === 27) this.handleClose();
+    },
+  },
+};
+</script>

--- a/cmd/wallet-web/src/components/Modal/ModalLayout.vue
+++ b/cmd/wallet-web/src/components/Modal/ModalLayout.vue
@@ -1,0 +1,42 @@
+<template>
+  <div
+    v-show="isOpen"
+    class="flex overflow-y-auto fixed inset-0 z-50 justify-center items-center bg-gradient-harold"
+    :class="{ open: isOpen }"
+    @click="$emit('onClose')"
+  >
+    <div
+      class="relative mx-6 lg:mx-auto max-w-6xl bg-neutrals-white rounded-2xl modal-width"
+      :class="{ open: isOpen }"
+      @click.stop
+    >
+      <div v-if="title" class="pt-5 pb-3 text-lg font-bold text-neutrals-dark">{{ title }}</div>
+      <div>
+        <slot />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'Modal',
+  props: {
+    isOpen: {
+      type: Boolean,
+      default: false,
+    },
+    title: {
+      type: String,
+      default: 'Credential',
+    },
+  },
+};
+</script>
+
+<style scoped>
+.modal-width {
+  width: 28rem;
+  box-shadow: 0px 12px 48px 0px rgba(25, 12, 33, 0.2);
+}
+</style>

--- a/cmd/wallet-web/src/pages/CredentialDetails.vue
+++ b/cmd/wallet-web/src/pages/CredentialDetails.vue
@@ -12,7 +12,28 @@
       <div
         class="inline-flex items-center rounded-lg border border-neutrals-chatelle bg-transparent"
       >
-        <flyout-menu type="outline" :credential-id="credential.id" />
+        <flyout-menu type="outline">
+          <flyout-menu-list>
+            <flyout-menu-button
+              id="renameCredential"
+              :text="i18n.renameCredential"
+              color="neutrals-medium"
+            />
+            <flyout-menu-button
+              id="moveCredential"
+              :text="i18n.moveCredential"
+              color="neutrals-medium"
+            />
+            <flyout-menu-button
+              id="deleteCredential"
+              :text="i18n.deleteCredential"
+              color="primary-vampire"
+              @click="openDeleteCredential"
+            >
+            </flyout-menu-button>
+          </flyout-menu-list>
+        </flyout-menu>
+        <ModalRoot />
       </div>
     </div>
     <banner
@@ -48,8 +69,14 @@
 </template>
 
 <script>
+import { ModalBus } from '@/EventBus';
+import ModalRoot from '@/components/Modal/Modal';
+import DeleteCredential from '@/components/Modal/Credential/Delete';
 import Banner from '@/components/CredentialDetails/Banner';
 import FlyoutMenu from '@/components/FlyoutMenu/FlyoutMenu';
+import FlyoutMenuList from '@/components/FlyoutMenu/FlyoutMenuList';
+import FlyoutMenuButton from '@/components/FlyoutMenu/FlyoutMenuButton';
+
 import { mapGetters } from 'vuex';
 
 export default {
@@ -57,6 +84,14 @@ export default {
   components: {
     Banner,
     FlyoutMenu,
+    FlyoutMenuList,
+    FlyoutMenuButton,
+    ModalRoot,
+  },
+  data: function () {
+    return {
+      modalAuth: false,
+    };
   },
   computed: {
     i18n() {
@@ -65,6 +100,15 @@ export default {
     ...mapGetters(['getProcessedCredentialByID']),
     credential() {
       return this.getProcessedCredentialByID(this.$route.params.id);
+    },
+  },
+  methods: {
+    // Add modal bus event for other modal like rename, move credential etc
+    openDeleteCredential() {
+      ModalBus.$emit('open', {
+        component: DeleteCredential,
+        props: { credentialId: this.credential.id },
+      });
     },
   },
 };

--- a/cmd/wallet-web/src/plugins/i18n.js
+++ b/cmd/wallet-web/src/plugins/i18n.js
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 import VueI18n from 'vue-i18n';
 import { setDocumentLang, setDocumentTitle } from '@/utils/i18n/document';
-import EventBus from '@/EventBus';
 
 Vue.use(VueI18n);
 
@@ -15,17 +14,13 @@ const i18n = new VueI18n({
 
 // This function updates i18n locale, loads new locale's messages and sets document properties accordingly
 export async function updateI18nLocale(locale) {
-  EventBus.$emit('i18n-load-start');
-
   if (loadedLanguages.length > 0 && i18n.locale === locale) {
-    EventBus.$emit('i18n-load-complete');
     return;
   }
 
   // If the language was already loaded
   if (loadedLanguages.includes(locale)) {
     i18n.locale = locale;
-    EventBus.$emit('i18n-load-complete');
     setDocumentLang(locale);
     setDocumentTitle(i18n.t('App.title'));
     return;
@@ -40,7 +35,6 @@ export async function updateI18nLocale(locale) {
   setDocumentTitle(i18n.t('App.title'));
   i18n.locale = locale;
   loadedLanguages.push(locale);
-  EventBus.$emit('i18n-load-complete');
   return;
 }
 

--- a/cmd/wallet-web/src/translations/CredentialDetails/fr.json
+++ b/cmd/wallet-web/src/translations/CredentialDetails/fr.json
@@ -13,7 +13,7 @@
   "renameCredential": "Renommer l’identifiant",
   "moveCredential": "Déplacer l’identifiant",
   "deleteCredential": "Supprimer l’identifiant",
-  "ddeleteButtonLabel": "Supprimer",
+  "deleteButtonLabel": "Supprimer",
   "deleteButtonCancel": "Annuler",
   "deleteCredentialConfirmMessage": "Vous ne pourrez plus partager cet preuve d’identité."
 }


### PR DESCRIPTION
closes #1184
closes #1192
closes #1157

This is an example video we can now inject different modal for rename , move etc easily. 
https://user-images.githubusercontent.com/7862595/140038177-92a7dd83-fa02-4f1c-b984-2a62cf081575.mov

https://user-images.githubusercontent.com/7862595/140038724-b82f516b-1d6e-4129-b4bb-7acc6470c4d3.mov



Example of reusable flyout menu in the vault . This will be implemented in the vault page in the separate pr. 
<img width="1620" alt="Screen Shot 2021-11-03 at 4 10 14 AM" src="https://user-images.githubusercontent.com/7862595/140038321-7991803e-7e08-4ddb-8a99-04dc7c5cc0ac.png">

<img width="1569" alt="Screen Shot 2021-11-03 at 4 27 38 AM" src="https://user-images.githubusercontent.com/7862595/140038438-5ec6f6e9-ef53-4b2a-8b50-e2e75ce44e30.png">




Signed-off-by: talwinder50 <talwinderkaur50@gmail.com>