### PR TITLE
fix: use base64url encoding for credential id

### DIFF
--- a/cmd/wallet-web/src/pages/mixins/common/helper.js
+++ b/cmd/wallet-web/src/pages/mixins/common/helper.js
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 import jp from 'jsonpath';
-const { Base64 } = require('js-base64');
+const { encodeURI } = require('js-base64');
 import { PresentationExchange } from './presentationExchange';
 
 var flatten = require('flat');
@@ -199,7 +199,7 @@ function getTermInContext(ctxObj, term) {
 
 // function to get the credential display data
 export function getCredentialDisplayData(vc, manifest, skipEmpty = true) {
-  const id = Base64.encode(populatePath(vc, manifest.id));
+  const id = encodeURI(populatePath(vc, manifest.id));
   const brandColor = manifest.brandColor || '';
   const issuanceDate = populatePath(vc, manifest.issuanceDate);
   const title = populatePath(vc, manifest.title.path) || manifest.title.fallback;


### PR DESCRIPTION
Fixes #1235

This PR replaces `Base64.encode()` with `Base64.encodeURI()` to ensure base64-url encoding. The `Base64.decode()` function is universal and works with both `base64` and `base64-url`-encoded strings, so we do not need to touch it.

Signed-off-by: Anton Biriukov <anton.biriukov@securekey.com>