### PR TITLE
fix: updated tailwind imports in mock test pages

### DIFF
--- a/test/mock/adapter/templates/css/tailwind.css
+++ b/test/mock/adapter/templates/css/tailwind.css
@@ -727,46 +727,6 @@ h6 {
   box-shadow: 0px 0px 0px 2px rgba(138, 53, 183, 0.7);
 }
 
-.btn-danger {
-  min-height: 2.75rem;
-  padding: 0 2rem;
-  border-radius: 0.5rem;
-  background-image: -webkit-gradient(
-    linear,
-    left top,
-    left bottom,
-    from(#e84c4c),
-    to(#670f0f)
-  );
-  background-image: linear-gradient(#e84c4c 0%, #670f0f 100%);
-  -webkit-box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.1);
-  box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.1);
-  color: #ffffff;
-  font-size: 1rem;
-  font-weight: 700;
-  -webkit-transition: all 200ms cubic-bezier(0.4, 0, 1, 1);
-  transition: all 200ms cubic-bezier(0.4, 0, 1, 1);
-}
-
-.btn-danger:hover {
-  background-image: -webkit-gradient(
-    linear,
-    left top,
-    left bottom,
-    from(#ff6666),
-    to(#670f0f)
-  );
-  background-image: linear-gradient(#ff6666 0%, #670f0f 100%);
-}
-
-.btn-danger:focus {
-  border: 2px solid #ffffff;
-  -webkit-box-shadow: 0px 0px 0px 2px rgba(174, 49, 49, 0.7),
-    0px 1px 2px 0px rgba(0, 0, 0, 0.1);
-  box-shadow: 0px 0px 0px 2px rgba(174, 49, 49, 0.7),
-    0px 1px 2px 0px rgba(0, 0, 0, 0.1);
-}
-
 .input-container {
   position: relative;
   margin-bottom: 1.5rem;
@@ -1065,16 +1025,16 @@ h6 {
   top: 1.25rem;
 }
 
-.top-6 {
-  top: 1.5rem;
+.top-14 {
+  top: 3.5rem;
 }
 
 .right-0 {
   right: 0px;
 }
 
-.right-32 {
-  right: 8rem;
+.right-4 {
+  right: 1rem;
 }
 
 .bottom-0 {
@@ -1423,10 +1383,6 @@ h6 {
   display: contents;
 }
 
-.list-item {
-  display: list-item;
-}
-
 .hidden {
   display: none;
 }
@@ -1547,16 +1503,8 @@ h6 {
   width: 5rem;
 }
 
-.w-40 {
-  width: 10rem;
-}
-
 .w-48 {
   width: 12rem;
-}
-
-.w-56 {
-  width: 14rem;
 }
 
 .w-1\/2 {
@@ -1583,6 +1531,10 @@ h6 {
   max-width: 28rem;
 }
 
+.max-w-lg {
+  max-width: 32rem;
+}
+
 .max-w-xl {
   max-width: 36rem;
 }
@@ -1591,22 +1543,12 @@ h6 {
   max-width: 48rem;
 }
 
-.max-w-6xl {
-  max-width: 72rem;
-}
-
 .max-w-7xl {
   max-width: 80rem;
 }
 
 .max-w-full {
   max-width: 100%;
-}
-
-.max-w-max {
-  max-width: -webkit-max-content;
-  max-width: -moz-max-content;
-  max-width: max-content;
 }
 
 .flex-1 {
@@ -1653,6 +1595,10 @@ h6 {
   transform: translateX(var(--tw-translate-x)) translateY(var(--tw-translate-y))
     rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
     scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.rotate-45 {
+  --tw-rotate: 45deg;
 }
 
 .rotate-90 {
@@ -1913,6 +1859,10 @@ h6 {
   overflow-wrap: break-word;
 }
 
+.rounded-sm {
+  border-radius: 0.125rem;
+}
+
 .rounded {
   border-radius: 0.25rem;
 }
@@ -1977,6 +1927,10 @@ h6 {
 
 .border-0 {
   border-width: 0px;
+}
+
+.border-8 {
+  border-width: 8px;
 }
 
 .border {
@@ -2055,6 +2009,10 @@ h6 {
   --tw-border-opacity: 0.1;
 }
 
+.border-opacity-20 {
+  --tw-border-opacity: 0.2;
+}
+
 .bg-transparent {
   background-color: transparent;
 }
@@ -2122,6 +2080,16 @@ h6 {
 .bg-gray-light {
   --tw-bg-opacity: 1;
   background-color: rgba(244, 241, 245, var(--tw-bg-opacity));
+}
+
+.hover\:bg-neutrals-softWhite:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgba(244, 241, 245, var(--tw-bg-opacity));
+}
+
+.focus\:bg-neutrals-mischka:focus {
+  --tw-bg-opacity: 1;
+  background-color: rgba(220, 218, 221, var(--tw-bg-opacity));
 }
 
 .bg-opacity-25 {
@@ -3048,14 +3016,6 @@ h6 {
   text-align: center;
 }
 
-.text-right {
-  text-align: right;
-}
-
-.text-justify {
-  text-align: justify;
-}
-
 .align-middle {
   vertical-align: middle;
 }
@@ -3276,6 +3236,11 @@ h6 {
     var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
     var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.outline-none {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
 }
 
 .focus\:outline-none:focus {
@@ -3674,11 +3639,6 @@ h6 {
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   -webkit-transition-duration: 150ms;
   transition-duration: 150ms;
-}
-
-.ease-out {
-  -webkit-transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
-  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
 }
 
 .ease-in-out {
@@ -4582,12 +4542,12 @@ h6 {
     height: 6rem;
   }
 
-  .md\:h-auto {
-    height: auto;
+  .md\:h-40 {
+    height: 10rem;
   }
 
-  .md\:h-full {
-    height: 100%;
+  .md\:h-auto {
+    height: auto;
   }
 
   .md\:min-h-screen {
@@ -4655,6 +4615,10 @@ h6 {
 
   .md\:rounded {
     border-radius: 0.25rem;
+  }
+
+  .md\:rounded-lg {
+    border-radius: 0.5rem;
   }
 
   .md\:border {
@@ -5225,8 +5189,8 @@ h6 {
     padding-bottom: 3rem;
   }
 
-  .md\:pt-10 {
-    padding-top: 2.5rem;
+  .md\:pt-5 {
+    padding-top: 1.25rem;
   }
 
   .md\:pt-12 {
@@ -5647,12 +5611,6 @@ h6 {
     -webkit-box-align: center;
     -ms-flex-align: center;
     align-items: center;
-  }
-
-  .lg\:justify-between {
-    -webkit-box-pack: justify;
-    -ms-flex-pack: justify;
-    justify-content: space-between;
   }
 
   .lg\:gap-x-8 {
@@ -6209,11 +6167,6 @@ h6 {
     padding: 1.5rem;
   }
 
-  .lg\:px-8 {
-    padding-left: 2rem;
-    padding-right: 2rem;
-  }
-
   .lg\:px-11 {
     padding-left: 2.75rem;
     padding-right: 2.75rem;
@@ -6221,10 +6174,6 @@ h6 {
 
   .lg\:pt-5 {
     padding-top: 1.25rem;
-  }
-
-  .lg\:text-left {
-    text-align: left;
   }
 
   .lg\:text-sm {

--- a/test/mock/adapter/templates/webWallet.html
+++ b/test/mock/adapter/templates/webWallet.html
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta charset="utf-8" />
-    <link href="css/styles.css" rel="stylesheet" />
+    <link href="css/tailwind.css" rel="stylesheet" />
     <title>Web Wallet Operations</title>
 
     <script src="https://unpkg.com/web-credential-handler@1.0.1/dist/web-credential-handler.min.js"></script>

--- a/test/mock/demo-login-consent-server/main.go
+++ b/test/mock/demo-login-consent-server/main.go
@@ -72,6 +72,7 @@ func main() {
 	http.HandleFunc("/consent", c.consent)
 
 	http.Handle("/img/", http.FileServer(http.Dir("templates")))
+	http.Handle("/css/", http.FileServer(http.Dir("templates")))
 
 	fmt.Println(http.ListenAndServe(":"+port, nil))
 }

--- a/test/mock/demo-login-consent-server/templates/bankconsent.html
+++ b/test/mock/demo-login-consent-server/templates/bankconsent.html
@@ -5,154 +5,316 @@ SPDX-License-Identifier: Apache-2.0
  -->
 
 <html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <meta charset="utf-8">
-    <link rel="icon" type="images/x-icon" href="img/logo.png" >
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <meta charset="utf-8" />
+    <link rel="icon" type="images/x-icon" href="img/logo.png" />
     <title>Bank Consent Page</title>
-    <meta name="description" content="">
-    <meta name="keywords" content="">
-    <meta name="author" content="">
+    <meta name="description" content="" />
+    <meta name="keywords" content="" />
+    <meta name="author" content="" />
 
-    <link rel="stylesheet" href="https://unpkg.com/tailwindcss/dist/tailwind.min.css">
-    <!--Replace with your tailwind.css once created-->
+    <link
+      href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css"
+      rel="stylesheet"
+    />
 
-    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link
+      href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
+    />
 
     <style>
-        .gradient {
-            background: linear-gradient(90deg, #006AC3 20%, #006AC3 100%);
-        }
+      .gradient {
+        background: linear-gradient(90deg, #006ac3 20%, #006ac3 100%);
+      }
     </style>
+  </head>
 
-</head>
-
-<body class="leading-normal tracking-normal text-white gradient" style="font-family: 'Source Sans Pro', sans-serif;">
-
-<!--Nav-->
-<div class="pt-16">
-<nav id="header" class="fixed w-full z-30 top-0 text-white">
-
-    <div class="w-full container mx-auto flex flex-wrap items-center justify-between mt-0 py-2">
-
-        <div class="pl-4 flex items-center">
-            <a class="toggleColour text-white no-underline hover:no-underline font-bold text-2xl lg:text-4xl"  href="javascript:history.back()">
-                <i class="fa fa-cubes px-2" style="font-size:32px;color:white; border-right: solid"></i>
-                TrustBloc Bank
+  <body
+    class="leading-normal tracking-normal text-white gradient"
+    style="font-family: 'Source Sans Pro', sans-serif"
+  >
+    <!--Nav-->
+    <div class="pt-16">
+      <nav id="header" class="fixed w-full z-30 top-0 text-white">
+        <div
+          class="
+            w-full
+            container
+            mx-auto
+            flex flex-wrap
+            items-center
+            justify-between
+            mt-0
+            py-2
+          "
+        >
+          <div class="pl-4 flex items-center">
+            <a
+              class="
+                toggleColour
+                text-white
+                no-underline
+                hover:no-underline
+                font-bold
+                text-2xl
+                lg:text-4xl
+              "
+              href="javascript:history.back()"
+            >
+              <i
+                class="fa fa-cubes px-2"
+                style="font-size: 32px; color: white; border-right: solid"
+              ></i>
+              TrustBloc Bank
             </a>
-        </div>
+          </div>
 
-        <div class="block lg:hidden pr-4">
-            <button id="nav-toggle" class="flex items-center p-1 text-orange-800 hover:text-gray-900">
-                <svg class="fill-current h-6 w-6" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><title>Menu</title><path d="M0 3h20v2H0V3zm0 6h20v2H0V9zm0 6h20v2H0v-2z"/></svg>
+          <div class="block lg:hidden pr-4">
+            <button
+              id="nav-toggle"
+              class="flex items-center p-1 text-orange-800 hover:text-gray-900"
+            >
+              <svg
+                class="fill-current h-6 w-6"
+                viewBox="0 0 20 20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <title>Menu</title>
+                <path d="M0 3h20v2H0V3zm0 6h20v2H0V9zm0 6h20v2H0v-2z" />
+              </svg>
             </button>
-        </div>
+          </div>
 
-        <div class="w-full flex-grow lg:flex lg:items-center lg:w-auto hidden lg:block mt-2 lg:mt-0 bg-white lg:bg-transparent text-black p-4 lg:p-0 z-20" id="nav-content">
+          <div
+            class="
+              w-full
+              flex-grow
+              lg:flex lg:items-center lg:w-auto
+              hidden
+              lg:block
+              mt-2
+              lg:mt-0
+              bg-white
+              lg:bg-transparent
+              text-black
+              p-4
+              lg:p-0
+              z-20
+            "
+            id="nav-content"
+          >
             <ul class="list-reset lg:flex justify-end flex-1 items-center">
-                <li class="mr-3">
-                    <a class="inline-block text-gray-400 no-underline hover:text-green hover:text-underline py-2 px-4" href="https://github.com/trustbloc/edge-sandbox"><i class="fa fa-github"></i></a>
-                </li>
+              <li class="mr-3">
+                <a
+                  class="
+                    inline-block
+                    text-gray-400
+                    no-underline
+                    hover:text-green hover:text-underline
+                    py-2
+                    px-4
+                  "
+                  href="https://github.com/trustbloc/edge-sandbox"
+                  ><i class="fa fa-github"></i
+                ></a>
+              </li>
             </ul>
+          </div>
         </div>
+        <hr class="border-b border-gray-100 opacity-25 my-0 py-0" />
+      </nav>
     </div>
-    <hr class="border-b border-gray-100 opacity-25 my-0 py-0" />
-</nav>
-</div>
 
-<section class="bg-white border-b py-4">
-    <div class="container mx-auto flex  flex-wrap pt-4 pb-12">
+    <section class="bg-white border-b py-4">
+      <div class="container mx-auto flex flex-wrap pt-4 pb-12">
         <div class="w-full md:w-1/3 p-6 flex flex-col flex-grow flex-shrink">
-            <div class="flex-none mt-auto bg-white rounded-b rounded-t-none overflow-hidden p-6">
-                <div class="flex items-center justify-center">
-                    <div class="max-w-3xl rounded shadow-lg">
-                        <div class="px-6 py-4 bg-white justify-center">
-                            <p class="font-bold text-xl text-black mb-2 text-center">Terms of Service</p>
-                            <p class="lg:text-lg sm:text-sm text-black mb-2">Use of this service is governed by the following terms and conditions. Please read these terms and conditions carefully, as by using this website you will be deemed to have agreed to them. If you do not agree with these terms and conditions, do not use this service.
+          <div
+            class="
+              flex-none
+              mt-auto
+              bg-white
+              rounded-b rounded-t-none
+              overflow-hidden
+              p-6
+            "
+          >
+            <div class="flex items-center justify-center">
+              <div class="max-w-3xl rounded shadow-lg">
+                <div class="px-6 py-4 bg-white justify-center">
+                  <p class="font-bold text-xl text-black mb-2 text-center">
+                    Terms of Service
+                  </p>
+                  <p class="lg:text-lg sm:text-sm text-black mb-2">
+                    Use of this service is governed by the following terms and
+                    conditions. Please read these terms and conditions
+                    carefully, as by using this website you will be deemed to
+                    have agreed to them. If you do not agree with these terms
+                    and conditions, do not use this service. TrustBloc Flow
+                    provides user with a way to obtaining their digital ID as a
+                    Verifiable Credential. The personal information you provide
+                    ((Name, Email, Date of Birth and Address etc) will be used
+                    for the purpose of issuing the Verified Person credential
+                    under the authority of section 33(a) of the Freedom of
+                    Information and Protection of Privacy Act. You will be able
+                    to receive your "Open" Verified Person credential on online
+                    user wallet. TrustBloc’s collection of your personal
+                    information is under the authority of section 26(c) of the
+                    Freedom of Information and Protection of Privacy Act. If you
+                    have any questions about our collection or use of personal
+                    information, please direct your inquiries to the TrustBloc
+                    Dev team on github.
+                  </p>
+                  <p class="font-bold text-xl text-black mb-2 text-center">
+                    Limitation of Liabilities
+                  </p>
+                  <p class="lg:text-lg sm:text-sm text-black mb-2">
+                    Under no circumstances will the TrustBloc Application be
+                    liable to any person or business entity for any direct,
+                    indirect, special, incidental, consequential, or other
+                    damages based on any use of this website or any other
+                    website to which this site is linked, including, without
+                    limitation, any lost profits, business interruption, or loss
+                    of programs or information, even if the Government has been
+                    specifically advised of the possibility of such damages.
+                  </p>
+                  <div class="divide-y divide-gray-700">
+                    <div class="text-center py-2"></div>
+                    <div class="text-center py-2"></div>
+                  </div>
+                  <form action="" method="POST">
+                    <p class="text-black text-lg">
+                      <input
+                        class="mr-2 leading-tight filled-in"
+                        type="checkbox"
+                        name="agree"
+                        checked="checked"
+                      />
+                      I agree with the above terms and conditions {{.User}} ,
+                      application
+                      <strong>{{.ClientID}}</strong> can access the resource
+                    </p>
+                    <br />
 
-                                TrustBloc Flow provides user with a way to obtaining their digital ID as a Verifiable Credential.
-
-                                The personal information you provide ((Name, Email, Date of Birth and Address etc) will be used for the purpose of issuing the Verified Person credential under the authority of section 33(a) of the Freedom of Information and Protection of Privacy Act. You will be able to receive your "Open" Verified Person credential on online user wallet. TrustBloc’s collection of your personal information is under the authority of section 26(c) of the Freedom of Information and Protection of Privacy Act.
-
-                                If you have any questions about our collection or use of personal information, please direct your inquiries to the TrustBloc Dev team on github.</p>
-                            <p class="font-bold text-xl text-black mb-2 text-center">Limitation of Liabilities</p>
-                            <p class="lg:text-lg sm:text-sm text-black mb-2">Under no circumstances will the TrustBloc Application be liable to any person or business entity for any direct, indirect, special, incidental, consequential, or other damages based on any use of this website or any other website to which this site is linked, including, without limitation, any lost profits, business interruption, or loss of programs or information, even if the Government has been specifically advised of the possibility of such damages.</p>
-                            <div class="divide-y divide-gray-700">
-                                <div class="text-center py-2"></div>
-                                <div class="text-center py-2"></div>
-                            </div>
-                            <form action="" method="POST">
-                                <p class="text-black text-lg"><input class="mr-2 leading-tight filled-in" type="checkbox" name="agree" checked="checked" />
-                                    I agree with the above terms and conditions {{.User}} , application <strong>{{.ClientID}}</strong> can access the resource</p>
-                                <br>
-                                <p>
-                                    <input type="hidden" name="challenge" value="{{.Challenge}}">
-                                <div class="grid grid-cols-2 gap-8">
-                                    <div>
-                                        <button type="submit" name="submit" id="reject" class="col-start-1 col-end-2 bg-transparent hover:bg-red-700 text-black font-semibold hover:text-white px-4 py-2 m-2 border border-red-500 hover:border-transparent rounded"      value="reject" >Deny</button>
-                                    </div>
-                                    <div class="flex justify-end">
-                                        <button type="submit" name="submit" id="accept" class="col-end-2 col-span-2 bg-transparent hover:bg-green-400 text-green-700 font-semibold hover:text-white px-4 py-2 m-2 border border-green-500 hover:border-transparent rounded"  value="accept" >Agree</button>
-                                    </div>
-                                </div>
-                                </p>
-                            </form>
-                        </div>
+                    <input
+                      type="hidden"
+                      name="challenge"
+                      value="{{.Challenge}}"
+                    />
+                    <div class="grid grid-cols-2 gap-8">
+                      <div>
+                        <button
+                          type="submit"
+                          name="submit"
+                          id="reject"
+                          class="
+                            col-start-1 col-end-2
+                            bg-transparent
+                            hover:bg-red-700
+                            text-black
+                            font-semibold
+                            hover:text-white
+                            px-4
+                            py-2
+                            m-2
+                            border border-red-500
+                            hover:border-transparent
+                            rounded
+                          "
+                          value="reject"
+                        >
+                          Deny
+                        </button>
+                      </div>
+                      <div class="flex justify-end">
+                        <button
+                          type="submit"
+                          name="submit"
+                          id="accept"
+                          class="
+                            col-end-2 col-span-2
+                            bg-transparent
+                            hover:bg-green-400
+                            text-green-700
+                            font-semibold
+                            hover:text-white
+                            px-4
+                            py-2
+                            m-2
+                            border border-green-500
+                            hover:border-transparent
+                            rounded
+                          "
+                          value="accept"
+                        >
+                          Agree
+                        </button>
+                      </div>
                     </div>
+                  </form>
                 </div>
+              </div>
             </div>
+          </div>
         </div>
-
-    </div>
-</section>
-
-<footer>
-    <section class="container mx-auto text-center py-2">
-        <div class="text-lg text-white font py-1">
-            Copyright &copy; <a href="https://securekey.com/" rel="nofollow">SecureKey Technologies</a> and the TrustBloc Contributors.
-        </div>
+      </div>
     </section>
-</footer>
 
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <footer>
+      <section class="container mx-auto text-center py-2">
+        <div class="text-lg text-white font py-1">
+          Copyright &copy;
+          <a href="https://securekey.com/" rel="nofollow"
+            >SecureKey Technologies</a
+          >
+          and the TrustBloc Contributors.
+        </div>
+      </section>
+    </footer>
 
-<script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 
-    var navMenuDiv = document.getElementById("nav-content");
-    var navMenu = document.getElementById("nav-toggle");
+    <script>
+      var navMenuDiv = document.getElementById("nav-content");
+      var navMenu = document.getElementById("nav-toggle");
 
-    document.onclick = check;
-    function check(e){
+      document.onclick = check;
+      function check(e) {
         var target = (e && e.target) || (event && event.srcElement);
 
         //Nav Menu
         if (!checkParent(target, navMenuDiv)) {
-            // click NOT on the menu
-            if (checkParent(target, navMenu)) {
-                // click on the link
-                if (navMenuDiv.classList.contains("hidden")) {
-                    navMenuDiv.classList.remove("hidden");
-                } else {navMenuDiv.classList.add("hidden");}
+          // click NOT on the menu
+          if (checkParent(target, navMenu)) {
+            // click on the link
+            if (navMenuDiv.classList.contains("hidden")) {
+              navMenuDiv.classList.remove("hidden");
             } else {
-                // click both outside link and outside menu, hide menu
-                navMenuDiv.classList.add("hidden");
+              navMenuDiv.classList.add("hidden");
             }
+          } else {
+            // click both outside link and outside menu, hide menu
+            navMenuDiv.classList.add("hidden");
+          }
         }
-    }
+      }
 
-    function checkParent(t, elm) {
-        while(t.parentNode) {
-            if( t == elm ) {return true;}
-            t = t.parentNode;
+      function checkParent(t, elm) {
+        while (t.parentNode) {
+          if (t == elm) {
+            return true;
+          }
+          t = t.parentNode;
         }
         return false;
-    }
-
-</script>
-</body>
-
+      }
+    </script>
+  </body>
 </html>

--- a/test/mock/demo-login-consent-server/templates/banklogin.html
+++ b/test/mock/demo-login-consent-server/templates/banklogin.html
@@ -5,148 +5,304 @@ SPDX-License-Identifier: Apache-2.0
  -->
 
 <html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <meta charset="utf-8">
-    <link rel="icon" type="images/x-icon" href="img/logo.png" >
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <meta charset="utf-8" />
+    <link rel="icon" type="images/x-icon" href="img/logo.png" />
     <title>Bank Login Page</title>
-    <meta name="description" content="">
-    <meta name="keywords" content="">
-    <meta name="author" content="">
+    <meta name="description" content="" />
+    <meta name="keywords" content="" />
+    <meta name="author" content="" />
 
-    <link rel="stylesheet" href="https://unpkg.com/tailwindcss/dist/tailwind.min.css">
-    <!--Replace with your tailwind.css once created-->
+    <link
+      href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css"
+      rel="stylesheet"
+    />
 
-    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link
+      href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
+    />
 
     <style>
-        .gradient {
-            background: linear-gradient(90deg, #006AC3 20%, #006AC3 100%);
-        }
+      .gradient {
+        background: linear-gradient(90deg, #006ac3 20%, #006ac3 100%);
+      }
     </style>
+  </head>
 
-</head>
-
-<body class="leading-normal tracking-normal text-white gradient" style="font-family: 'Source Sans Pro', sans-serif;">
-
-<!--Nav-->
-<div class="pt-16">
-<nav id="header" class="fixed w-full z-30 top-0 text-white">
-
-    <div class="w-full container mx-auto flex flex-wrap items-center justify-between mt-0 py-2">
-
-        <div class="pl-4 flex items-center">
-            <a class="toggleColour text-white no-underline hover:no-underline font-bold text-2xl lg:text-4xl"  href="javascript:history.back()">
-                <i class="fa fa-cubes px-2" style="font-size:32px;color:white; border-right: solid"></i>
-                TrustBloc Bank
+  <body
+    class="leading-normal tracking-normal text-white gradient"
+    style="font-family: 'Source Sans Pro', sans-serif"
+  >
+    <!--Nav-->
+    <div class="pt-16">
+      <nav id="header" class="fixed w-full z-30 top-0 text-white">
+        <div
+          class="
+            w-full
+            container
+            mx-auto
+            flex flex-wrap
+            items-center
+            justify-between
+            mt-0
+            py-2
+          "
+        >
+          <div class="pl-4 flex items-center">
+            <a
+              class="
+                toggleColour
+                text-white
+                no-underline
+                hover:no-underline
+                font-bold
+                text-2xl
+                lg:text-4xl
+              "
+              href="javascript:history.back()"
+            >
+              <i
+                class="fa fa-cubes px-2"
+                style="font-size: 32px; color: white; border-right: solid"
+              ></i>
+              TrustBloc Bank
             </a>
-        </div>
+          </div>
 
-        <div class="w-full flex-grow lg:flex lg:items-center lg:w-auto hidden lg:block mt-2 lg:mt-0 bg-white lg:bg-transparent text-black p-4 lg:p-0 z-20" id="nav-content">
+          <div
+            class="
+              w-full
+              flex-grow
+              lg:flex lg:items-center lg:w-auto
+              hidden
+              lg:block
+              mt-2
+              lg:mt-0
+              bg-white
+              lg:bg-transparent
+              text-black
+              p-4
+              lg:p-0
+              z-20
+            "
+            id="nav-content"
+          >
             <ul class="list-reset lg:flex justify-end flex-1 items-center">
-                <li class="mr-3">
-                    <a class="inline-block text-gray-400 no-underline hover:text-green hover:text-underline py-2 px-4" href="https://github.com/trustbloc/edge-sandbox">
-                        <i class="fa fa-github"></i></a>
-                </li>
+              <li class="mr-3">
+                <a
+                  class="
+                    inline-block
+                    text-gray-400
+                    no-underline
+                    hover:text-green hover:text-underline
+                    py-2
+                    px-4
+                  "
+                  href="https://github.com/trustbloc/edge-sandbox"
+                >
+                  <i class="fa fa-github"></i
+                ></a>
+              </li>
             </ul>
+          </div>
         </div>
+        <hr class="border-b border-gray-100 opacity-25 my-0 py-0" />
+      </nav>
     </div>
-    <hr class="border-b border-gray-100 opacity-25 my-0 py-0" />
-</nav>
-</div>
 
-<section class="bg-white border-b py-48">
-    <div class="container mx-auto flex  flex-wrap pt-4 pb-12">
-        <div class="bg-blue w-full md:w-1/3 p-6 flex flex-col flex-grow flex-shrink">
-            <div class="flex-none mt-auto bg-white rounded-b rounded-t-none overflow-hidden p-6">
-                <div class=" flex items-center justify-center">
-                    <form class="shadow-md rounded px-16 pt-8 pb-8 md:flex-wrap md:justify-between gradient" action="/login" method="post">
-                        <p class="text-white lg:text-2xl sm:text-xs text-center">Sign in to Online Banking</p>
-                        </br>
+    <section class="bg-white border-b py-48">
+      <div class="container mx-auto flex flex-wrap pt-4 pb-12">
+        <div
+          class="
+            bg-blue
+            w-full
+            md:w-1/3
+            p-6
+            flex flex-col flex-grow flex-shrink
+          "
+        >
+          <div
+            class="
+              flex-none
+              mt-auto
+              bg-white
+              rounded-b rounded-t-none
+              overflow-hidden
+              p-6
+            "
+          >
+            <div class="flex items-center justify-center">
+              <form
+                class="
+                  shadow-md
+                  rounded
+                  px-16
+                  pt-8
+                  pb-8
+                  md:flex-wrap md:justify-between
+                  gradient
+                "
+                action="/login"
+                method="post"
+              >
+                <p class="text-white lg:text-2xl sm:text-xs text-center">
+                  Sign in to Online Banking
+                </p>
+                <br />
 
-                        <input type="hidden" name="challenge" value="{{.login_challenge}}">
+                <input
+                  type="hidden"
+                  name="challenge"
+                  value="{{.login_challenge}}"
+                />
 
-                        <div class="mb-4">
-                            <label class="block text-white text-lg font-bold mb-2 text-left" for="email">
-                                Client Card or Username (required)
-                            </label>
-                            <input class="shadow appearance-none border w-full py-2 px-8 text-gray-700
-                        leading-tight focus:outline-none focus:ring" type="tel" inputmode="numeric" pattern="[0-9\s]{13,19}" maxlength="19" value="4506 4456 4307 3456" required>
-                        </div>
-
-                        <div class="mb-6">
-                            <label class="block text-white text-lg font-bold mb-2 text-left" for="password">
-                                Password
-                            </label>
-                            <input class="shadow appearance-none border w-full py-2 px-8 text-gray-700 mb-3 leading-tight
-                        focus:outline-none focus:ring" id="password" name='password' type="password" value="f00B@r!23">
-                            <p class="text-green-200 text-xs italic text-left">For demo password is optional.</p>
-                        </div>
-                        <div class="container flex-auto  mb-6">
-                        <div class="w-full content-center mb-2 bg-yellow-400 py-2 text-center">
-                            <button class="mx-auto lg:mx-0  hover:underline font-bold text-xl text-black text-center" type='submit' id="accept" name='btn_login'>
-                                Login
-                            </button>
-                        </div>
-                        </div>
-                    </form>
+                <div class="mb-4">
+                  <label
+                    class="block text-white text-lg font-bold mb-2 text-left"
+                    for="email"
+                  >
+                    Client Card or Username (required)
+                  </label>
+                  <input
+                    class="
+                      shadow
+                      appearance-none
+                      border
+                      w-full
+                      py-2
+                      px-8
+                      text-gray-700
+                      leading-tight
+                      focus:outline-none focus:ring
+                    "
+                    type="tel"
+                    inputmode="numeric"
+                    pattern="[0-9\s]{13,19}"
+                    maxlength="19"
+                    value="4506 4456 4307 3456"
+                    required
+                  />
                 </div>
+
+                <div class="mb-6">
+                  <label
+                    class="block text-white text-lg font-bold mb-2 text-left"
+                    for="password"
+                  >
+                    Password
+                  </label>
+                  <input
+                    class="
+                      shadow
+                      appearance-none
+                      border
+                      w-full
+                      py-2
+                      px-8
+                      text-gray-700
+                      mb-3
+                      leading-tight
+                      focus:outline-none focus:ring
+                    "
+                    id="password"
+                    name="password"
+                    type="password"
+                    value="f00B@r!23"
+                  />
+                  <p class="text-green-200 text-xs italic text-left">
+                    For demo password is optional.
+                  </p>
+                </div>
+                <div class="container flex-auto mb-6">
+                  <div
+                    class="
+                      w-full
+                      content-center
+                      mb-2
+                      bg-yellow-400
+                      py-2
+                      text-center
+                    "
+                  >
+                    <button
+                      class="
+                        mx-auto
+                        lg:mx-0
+                        hover:underline
+                        font-bold
+                        text-xl text-black text-center
+                      "
+                      type="submit"
+                      id="accept"
+                      name="btn_login"
+                    >
+                      Login
+                    </button>
+                  </div>
+                </div>
+              </form>
             </div>
+          </div>
         </div>
-
-    </div>
-</section>
-
-<footer>
-    <section class="container mx-auto text-center py-2">
-        <div class="text-lg text-white font py-1">
-            Copyright &copy; <a href="https://securekey.com/" rel="nofollow">SecureKey Technologies</a> and the TrustBloc Contributors.
-        </div>
+      </div>
     </section>
-</footer>
 
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <footer>
+      <section class="container mx-auto text-center py-2">
+        <div class="text-lg text-white font py-1">
+          Copyright &copy;
+          <a href="https://securekey.com/" rel="nofollow"
+            >SecureKey Technologies</a
+          >
+          and the TrustBloc Contributors.
+        </div>
+      </section>
+    </footer>
 
-<script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 
-    var navMenuDiv = document.getElementById("nav-content");
-    var navMenu = document.getElementById("nav-toggle");
+    <script>
+      var navMenuDiv = document.getElementById("nav-content");
+      var navMenu = document.getElementById("nav-toggle");
 
-    document.onclick = check;
-    function check(e){
+      document.onclick = check;
+      function check(e) {
         var target = (e && e.target) || (event && event.srcElement);
 
         //Nav Menu
         if (!checkParent(target, navMenuDiv)) {
-            // click NOT on the menu
-            if (checkParent(target, navMenu)) {
-                // click on the link
-                if (navMenuDiv.classList.contains("hidden")) {
-                    navMenuDiv.classList.remove("hidden");
-                } else {navMenuDiv.classList.add("hidden");}
+          // click NOT on the menu
+          if (checkParent(target, navMenu)) {
+            // click on the link
+            if (navMenuDiv.classList.contains("hidden")) {
+              navMenuDiv.classList.remove("hidden");
             } else {
-                // click both outside link and outside menu, hide menu
-                navMenuDiv.classList.add("hidden");
+              navMenuDiv.classList.add("hidden");
             }
+          } else {
+            // click both outside link and outside menu, hide menu
+            navMenuDiv.classList.add("hidden");
+          }
         }
-    }
+      }
 
-    function checkParent(t, elm) {
-        while(t.parentNode) {
-            if( t == elm ) {return true;}
-            t = t.parentNode;
+      function checkParent(t, elm) {
+        while (t.parentNode) {
+          if (t == elm) {
+            return true;
+          }
+          t = t.parentNode;
         }
         return false;
-    }
-
-</script>
-
-
-</body>
-
+      }
+    </script>
+  </body>
 </html>
-

--- a/test/mock/demo-login-consent-server/templates/consent.html
+++ b/test/mock/demo-login-consent-server/templates/consent.html
@@ -5,195 +5,380 @@ SPDX-License-Identifier: Apache-2.0
  -->
 
 <html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <meta charset="utf-8">
-    <link rel="icon" type="images/x-icon" href="img/logo.png" >
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <meta charset="utf-8" />
+    <link rel="icon" type="images/x-icon" href="img/logo.png" />
     <title>Consent Page</title>
-    <meta name="description" content="">
-    <meta name="keywords" content="">
-    <meta name="author" content="">
+    <meta name="description" content="" />
+    <meta name="keywords" content="" />
+    <meta name="author" content="" />
 
-    <link rel="stylesheet" href="https://unpkg.com/tailwindcss/dist/tailwind.min.css">
-    <!--Replace with your tailwind.css once created-->
+    <link
+      href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css"
+      rel="stylesheet"
+    />
 
-    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link
+      href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
+    />
 
     <style>
-        .gradient {
-            background: linear-gradient(90deg, #000046 20%, #000046 100%);
-        }
+      .gradient {
+        background: linear-gradient(90deg, #000046 20%, #000046 100%);
+      }
     </style>
+  </head>
 
-</head>
-
-<body class="leading-normal tracking-normal text-white gradient" style="font-family: 'Source Sans Pro', sans-serif;">
-
-<!--Nav-->
-<nav id="header" class="fixed w-full z-30 top-0 text-white">
-
-    <div class="w-full container mx-auto flex flex-wrap items-center justify-between mt-0 py-2">
-
+  <body
+    class="leading-normal tracking-normal text-white gradient"
+    style="font-family: 'Source Sans Pro', sans-serif"
+  >
+    <!--Nav-->
+    <nav id="header" class="fixed w-full z-30 top-0 text-white">
+      <div
+        class="
+          w-full
+          container
+          mx-auto
+          flex flex-wrap
+          items-center
+          justify-between
+          mt-0
+          py-2
+        "
+      >
         <div class="pl-4 flex items-center">
-            <a class="toggleColour text-white no-underline hover:no-underline font-bold text-2xl lg:text-4xl"  href="javascript:history.back()">
-                <i class="fa fa-cubes" style="font-size:32px;color:white"></i>
-                TrustBloc Issuer
-            </a>
+          <a
+            class="
+              toggleColour
+              text-white
+              no-underline
+              hover:no-underline
+              font-bold
+              text-2xl
+              lg:text-4xl
+            "
+            href="javascript:history.back()"
+          >
+            <i class="fa fa-cubes" style="font-size: 32px; color: white"></i>
+            TrustBloc Issuer
+          </a>
         </div>
 
         <div class="block lg:hidden pr-4">
-            <button id="nav-toggle" class="flex items-center p-1 text-orange-800 hover:text-gray-900">
-                <svg class="fill-current h-6 w-6" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><title>Menu</title><path d="M0 3h20v2H0V3zm0 6h20v2H0V9zm0 6h20v2H0v-2z"/></svg>
-            </button>
+          <button
+            id="nav-toggle"
+            class="flex items-center p-1 text-orange-800 hover:text-gray-900"
+          >
+            <svg
+              class="fill-current h-6 w-6"
+              viewBox="0 0 20 20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>Menu</title>
+              <path d="M0 3h20v2H0V3zm0 6h20v2H0V9zm0 6h20v2H0v-2z" />
+            </svg>
+          </button>
         </div>
 
-        <div class="w-full flex-grow lg:flex lg:items-center lg:w-auto hidden lg:block mt-2 lg:mt-0 bg-white lg:bg-transparent text-black p-4 lg:p-0 z-20" id="nav-content">
-            <ul class="list-reset lg:flex justify-end flex-1 items-center">
-                <li class="mr-3">
-                    <a class="inline-block text-gray-400 no-underline hover:text-green hover:text-underline py-2 px-4" href="https://github.com/trustbloc/edge-sandbox"><i class="fa fa-github"></i></a>
-                </li>
-            </ul>
+        <div
+          class="
+            w-full
+            flex-grow
+            lg:flex lg:items-center lg:w-auto
+            hidden
+            lg:block
+            mt-2
+            lg:mt-0
+            bg-white
+            lg:bg-transparent
+            text-black
+            p-4
+            lg:p-0
+            z-20
+          "
+          id="nav-content"
+        >
+          <ul class="list-reset lg:flex justify-end flex-1 items-center">
+            <li class="mr-3">
+              <a
+                class="
+                  inline-block
+                  text-gray-400
+                  no-underline
+                  hover:text-green hover:text-underline
+                  py-2
+                  px-4
+                "
+                href="https://github.com/trustbloc/edge-sandbox"
+                ><i class="fa fa-github"></i
+              ></a>
+            </li>
+          </ul>
         </div>
-    </div>
-    <hr class="border-b border-gray-100 opacity-25 my-0 py-0" />
-</nav>
+      </div>
+      <hr class="border-b border-gray-100 opacity-25 my-0 py-0" />
+    </nav>
 
-
-<div class="pt-12">
-
-    <div class="container px-3 mx-auto flex flex-wrap flex-col md:flex-row items-center">
+    <div class="pt-12">
+      <div
+        class="
+          container
+          px-3
+          mx-auto
+          flex flex-wrap flex-col
+          md:flex-row
+          items-center
+        "
+      >
         <!--Left Col-->
-        <div class="flex flex-col w-full md:w-2/5 justify-center items-start text-center md:text-left">
-            <h1 class="my-4 text-5xl font-bold leading-tight"></h1>
+        <div
+          class="
+            flex flex-col
+            w-full
+            md:w-2/5
+            justify-center
+            items-start
+            text-center
+            md:text-left
+          "
+        >
+          <h1 class="my-4 text-5xl font-bold leading-tight"></h1>
         </div>
+      </div>
     </div>
-</div>
 
-
-<div class="relative -mt-12 lg:-mt-32">
-    <svg viewBox="0 0 1428 174" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <div class="relative -mt-12 lg:-mt-32">
+      <svg
+        viewBox="0 0 1428 174"
+        version="1.1"
+        xmlns="http://www.w3.org/2000/svg"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+      >
         <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-            <g transform="translate(-2.000000, 44.000000)" fill="#FFFFFF" fill-rule="nonzero">
-                <path d="M0,0 C90.7283404,0.927527913 147.912752,27.187927 291.910178,59.9119003 C387.908462,81.7278826 543.605069,89.334785 759,82.7326078 C469.336065,156.254352 216.336065,153.6679 0,74.9732496" opacity="0.100000001"></path>
-                <path d="M100,104.708498 C277.413333,72.2345949 426.147877,52.5246657 546.203633,45.5787101 C666.259389,38.6327546 810.524845,41.7979068 979,55.0741668 C931.069965,56.122511 810.303266,74.8455141 616.699903,111.243176 C423.096539,147.640838 250.863238,145.462612 100,104.708498 Z" opacity="0.100000001"></path>
-                <path d="M1046,51.6521276 C1130.83045,29.328812 1279.08318,17.607883 1439,40.1656806 L1439,120 C1271.17211,77.9435312 1140.17211,55.1609071 1046,51.6521276 Z" id="Path-4" opacity="0.200000003"></path>
-            </g>
-            <g transform="translate(-4.000000, 76.000000)" fill="#FFFFFF" fill-rule="nonzero">
-                <path d="M0.457,34.035 C57.086,53.198 98.208,65.809 123.822,71.865 C181.454,85.495 234.295,90.29 272.033,93.459 C311.355,96.759 396.635,95.801 461.025,91.663 C486.76,90.01 518.727,86.372 556.926,80.752 C595.747,74.596 622.372,70.008 636.799,66.991 C663.913,61.324 712.501,49.503 727.605,46.128 C780.47,34.317 818.839,22.532 856.324,15.904 C922.689,4.169 955.676,2.522 1011.185,0.432 C1060.705,1.477 1097.39,3.129 1121.236,5.387 C1161.703,9.219 1208.621,17.821 1235.4,22.304 C1285.855,30.748 1354.351,47.432 1440.886,72.354 L1441.191,104.352 L1.121,104.031 L0.457,34.035 Z"></path>
-            </g>
+          <g
+            transform="translate(-2.000000, 44.000000)"
+            fill="#FFFFFF"
+            fill-rule="nonzero"
+          >
+            <path
+              d="M0,0 C90.7283404,0.927527913 147.912752,27.187927 291.910178,59.9119003 C387.908462,81.7278826 543.605069,89.334785 759,82.7326078 C469.336065,156.254352 216.336065,153.6679 0,74.9732496"
+              opacity="0.100000001"
+            ></path>
+            <path
+              d="M100,104.708498 C277.413333,72.2345949 426.147877,52.5246657 546.203633,45.5787101 C666.259389,38.6327546 810.524845,41.7979068 979,55.0741668 C931.069965,56.122511 810.303266,74.8455141 616.699903,111.243176 C423.096539,147.640838 250.863238,145.462612 100,104.708498 Z"
+              opacity="0.100000001"
+            ></path>
+            <path
+              d="M1046,51.6521276 C1130.83045,29.328812 1279.08318,17.607883 1439,40.1656806 L1439,120 C1271.17211,77.9435312 1140.17211,55.1609071 1046,51.6521276 Z"
+              id="Path-4"
+              opacity="0.200000003"
+            ></path>
+          </g>
+          <g
+            transform="translate(-4.000000, 76.000000)"
+            fill="#FFFFFF"
+            fill-rule="nonzero"
+          >
+            <path
+              d="M0.457,34.035 C57.086,53.198 98.208,65.809 123.822,71.865 C181.454,85.495 234.295,90.29 272.033,93.459 C311.355,96.759 396.635,95.801 461.025,91.663 C486.76,90.01 518.727,86.372 556.926,80.752 C595.747,74.596 622.372,70.008 636.799,66.991 C663.913,61.324 712.501,49.503 727.605,46.128 C780.47,34.317 818.839,22.532 856.324,15.904 C922.689,4.169 955.676,2.522 1011.185,0.432 C1060.705,1.477 1097.39,3.129 1121.236,5.387 C1161.703,9.219 1208.621,17.821 1235.4,22.304 C1285.855,30.748 1354.351,47.432 1440.886,72.354 L1441.191,104.352 L1.121,104.031 L0.457,34.035 Z"
+            ></path>
+          </g>
         </g>
-    </svg>
-</div>
-
-
-<section class="bg-white border-b py-24">
-    <div class="container mx-auto flex  flex-wrap pt-4 pb-12">
-        <div class="w-full md:w-1/3 p-6 flex flex-col flex-grow flex-shrink">
-            <div class="flex-none mt-auto bg-white rounded-b rounded-t-none overflow-hidden p-6">
-                <div class="flex items-center justify-center">
-                    <div class="max-w-3xl rounded shadow-lg">
-                        <img class="object-scale-down h-48 w-full" src="img/consent.png">
-                        <div class="px-6 py-4 bg-gray-100 justify-center">
-                            <p class="font-bold text-xl text-black mb-2">An application requests access to your data</p>
-                            <form action="" method="POST">
-                                <p class="text-gray-700 text-base">Hi {{.User}}, application <strong>{{.ClientID}}</strong> wants access resources on your behalf:</p>
-                                {{range $element := .Scope}}
-                                <label class="md:w-2/3 block text-gray-500 font-bold">
-                                    <input class="mr-2 leading-tight filled-in" type="checkbox" id="{{$element}}" value="{{$element}}" name="grant_scope" checked="checked" />
-                                    <span class="text-lg text-black" id="scopeName" for="{{$element}}">{{$element}}</span>
-                                </label>
-                                {{end}}
-                                <br>
-                                <p>
-                                    <input type="hidden" name="challenge" value="{{.Challenge}}">
-                                <div class="grid grid-cols-2 gap-8">
-                                    <div>
-                                        <button type="submit" name="submit" id="reject" class="col-start-1 col-end-2 bg-transparent hover:bg-red-700 text-black font-semibold hover:text-white px-4 py-2 m-2 border border-red-500 hover:border-transparent rounded"      value="reject" >Deny</button>
-                                    </div>
-                                    <div class="flex justify-end">
-                                        <button type="submit" name="submit" id="accept" class="col-end-2 col-span-2 bg-transparent hover:bg-green-400 text-green-700 font-semibold hover:text-white px-4 py-2 m-2 border border-green-500 hover:border-transparent rounded"  value="accept" >Agree</button>
-                                    </div>
-                                </div>
-                                </p>
-                            </form>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-
+      </svg>
     </div>
-</section>
 
-<footer>
-    <section class="container mx-auto text-center py-6 mb-12">
-        <div class="text-lg text-white font py-1">
-            Copyright &copy; <a href="https://securekey.com/" rel="nofollow">SecureKey Technologies</a> and the TrustBloc Contributors.
+    <section class="bg-white border-b py-24">
+      <div class="container mx-auto flex flex-wrap pt-4 pb-12">
+        <div class="w-full md:w-1/3 p-6 flex flex-col flex-grow flex-shrink">
+          <div
+            class="
+              flex-none
+              mt-auto
+              bg-white
+              rounded-b rounded-t-none
+              overflow-hidden
+              p-6
+            "
+          >
+            <div class="flex items-center justify-center">
+              <div class="max-w-3xl rounded shadow-lg">
+                <img
+                  class="object-scale-down h-48 w-full"
+                  src="img/consent.png"
+                />
+                <div class="px-6 py-4 bg-gray-100 justify-center">
+                  <p class="font-bold text-xl text-black mb-2">
+                    An application requests access to your data
+                  </p>
+                  <form action="" method="POST">
+                    <p class="text-gray-700 text-base">
+                      Hi {{.User}}, application
+                      <strong>{{.ClientID}}</strong> wants access resources on
+                      your behalf:
+                    </p>
+                    {{range $element := .Scope}}
+                    <label class="md:w-2/3 block text-gray-500 font-bold">
+                      <input
+                        class="mr-2 leading-tight filled-in"
+                        type="checkbox"
+                        id="{{$element}}"
+                        value="{{$element}}"
+                        name="grant_scope"
+                        checked="checked"
+                      />
+                      <span
+                        class="text-lg text-black"
+                        id="scopeName"
+                        for="{{$element}}"
+                        >{{$element}}</span
+                      >
+                    </label>
+                    {{end}}
+                    <br />
+
+                    <input
+                      type="hidden"
+                      name="challenge"
+                      value="{{.Challenge}}"
+                    />
+                    <div class="grid grid-cols-2 gap-8">
+                      <div>
+                        <button
+                          type="submit"
+                          name="submit"
+                          id="reject"
+                          class="
+                            col-start-1 col-end-2
+                            bg-transparent
+                            hover:bg-red-700
+                            text-black
+                            font-semibold
+                            hover:text-white
+                            px-4
+                            py-2
+                            m-2
+                            border border-red-500
+                            hover:border-transparent
+                            rounded
+                          "
+                          value="reject"
+                        >
+                          Deny
+                        </button>
+                      </div>
+                      <div class="flex justify-end">
+                        <button
+                          type="submit"
+                          name="submit"
+                          id="accept"
+                          class="
+                            col-end-2 col-span-2
+                            bg-transparent
+                            hover:bg-green-400
+                            text-green-700
+                            font-semibold
+                            hover:text-white
+                            px-4
+                            py-2
+                            m-2
+                            border border-green-500
+                            hover:border-transparent
+                            rounded
+                          "
+                          value="accept"
+                        >
+                          Agree
+                        </button>
+                      </div>
+                    </div>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
+      </div>
     </section>
-</footer>
 
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <footer>
+      <section class="container mx-auto text-center py-6 mb-12">
+        <div class="text-lg text-white font py-1">
+          Copyright &copy;
+          <a href="https://securekey.com/" rel="nofollow"
+            >SecureKey Technologies</a
+          >
+          and the TrustBloc Contributors.
+        </div>
+      </section>
+    </footer>
 
-<script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 
-    var navMenuDiv = document.getElementById("nav-content");
-    var navMenu = document.getElementById("nav-toggle");
+    <script>
+      var navMenuDiv = document.getElementById("nav-content");
+      var navMenu = document.getElementById("nav-toggle");
 
-    document.onclick = check;
-    function check(e){
+      document.onclick = check;
+      function check(e) {
         var target = (e && e.target) || (event && event.srcElement);
 
         //Nav Menu
         if (!checkParent(target, navMenuDiv)) {
-            // click NOT on the menu
-            if (checkParent(target, navMenu)) {
-                // click on the link
-                if (navMenuDiv.classList.contains("hidden")) {
-                    navMenuDiv.classList.remove("hidden");
-                } else {navMenuDiv.classList.add("hidden");}
+          // click NOT on the menu
+          if (checkParent(target, navMenu)) {
+            // click on the link
+            if (navMenuDiv.classList.contains("hidden")) {
+              navMenuDiv.classList.remove("hidden");
             } else {
-                // click both outside link and outside menu, hide menu
-                navMenuDiv.classList.add("hidden");
+              navMenuDiv.classList.add("hidden");
             }
+          } else {
+            // click both outside link and outside menu, hide menu
+            navMenuDiv.classList.add("hidden");
+          }
         }
-    }
+      }
 
-    function checkParent(t, elm) {
-        while(t.parentNode) {
-            if( t == elm ) {return true;}
-            t = t.parentNode;
+      function checkParent(t, elm) {
+        while (t.parentNode) {
+          if (t == elm) {
+            return true;
+          }
+          t = t.parentNode;
         }
         return false;
-    }
-
-</script>
-<script type="text/javascript">
-    // todo : Add friendly name for the scope issue-508
-    function getScopeName(name) {
+      }
+    </script>
+    <script type="text/javascript">
+      // todo : Add friendly name for the scope issue-508
+      function getScopeName(name) {
         var scopes = {
-            'mDL': 'Driving License',
-            'StudentCard': 'Student Card',
-            'TravelCard': 'Travel Card',
-            'UniversityDegreeCredential': 'University Degree',
-            'CertifiedMillTestReport': 'Credit Mill Test Report',
-            'CrudeProductCredential': 'Crude Product Credential',
-            'PermanentResidentCard': 'Permanent Resident Card',
-            'CreditCardStatement': 'Credit Card Statement',
-            'CreditScore': 'Credit Score Report',
+          mDL: "Driving License",
+          StudentCard: "Student Card",
+          TravelCard: "Travel Card",
+          UniversityDegreeCredential: "University Degree",
+          CertifiedMillTestReport: "Credit Mill Test Report",
+          CrudeProductCredential: "Crude Product Credential",
+          PermanentResidentCard: "Permanent Resident Card",
+          CreditCardStatement: "Credit Card Statement",
+          CreditScore: "Credit Score Report",
         };
         return scopes[name];
-    }
-    $(document).ready(function () {
-        var name = document.getElementById("scopeName").innerText
-        var scopeName =  getScopeName(name);
+      }
+      $(document).ready(function () {
+        var name = document.getElementById("scopeName").innerText;
+        var scopeName = getScopeName(name);
         document.getElementById("scopeName").innerText = scopeName;
-    });
-</script>
-</body>
-
+      });
+    </script>
+  </body>
 </html>

--- a/test/mock/demo-login-consent-server/templates/css/tailwind.css
+++ b/test/mock/demo-login-consent-server/templates/css/tailwind.css
@@ -1,0 +1,8984 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+/*
+! tailwindcss v2.2.19 | MIT License | https://tailwindcss.com
+*/
+
+/*! modern-normalize v1.1.0 | MIT License | https://github.com/sindresorhus/modern-normalize */
+
+/*
+Document
+========
+*/
+
+/**
+Use a better box model (opinionated).
+*/
+
+*,
+::before,
+::after {
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+/**
+Use a more readable tab size (opinionated).
+*/
+
+html {
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+}
+
+/**
+1. Correct the line height in all browsers.
+2. Prevent adjustments of font size after orientation changes in iOS.
+*/
+
+html {
+  line-height: 1.15;
+  /* 1 */
+  -webkit-text-size-adjust: 100%;
+  /* 2 */
+}
+
+/*
+Sections
+========
+*/
+
+/**
+Remove the margin in all browsers.
+*/
+
+body {
+  margin: 0;
+}
+
+/**
+Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3)
+*/
+
+body {
+  font-family: system-ui, -apple-system,
+    /* Firefox supports this but not yet `system-ui` */ "Segoe UI", Roboto,
+    Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+}
+
+/*
+Grouping content
+================
+*/
+
+/**
+1. Add the correct height in Firefox.
+2. Correct the inheritance of border color in Firefox. (https://bugzilla.mozilla.org/show_bug.cgi?id=190655)
+*/
+
+hr {
+  height: 0;
+  /* 1 */
+  color: inherit;
+  /* 2 */
+}
+
+/*
+Text-level semantics
+====================
+*/
+
+/**
+Add the correct text decoration in Chrome, Edge, and Safari.
+*/
+
+abbr[title] {
+  -webkit-text-decoration: underline dotted;
+  text-decoration: underline dotted;
+}
+
+/**
+Add the correct font weight in Edge and Safari.
+*/
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/**
+1. Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3)
+2. Correct the odd 'em' font sizing in all browsers.
+*/
+
+code,
+kbd,
+samp,
+pre {
+  font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", Menlo,
+    monospace;
+  /* 1 */
+  font-size: 1em;
+  /* 2 */
+}
+
+/**
+Add the correct font size in all browsers.
+*/
+
+small {
+  font-size: 80%;
+}
+
+/**
+Prevent 'sub' and 'sup' elements from affecting the line height in all browsers.
+*/
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/*
+Tabular data
+============
+*/
+
+/**
+1. Remove text indentation from table contents in Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=999088, https://bugs.webkit.org/show_bug.cgi?id=201297)
+2. Correct table border color inheritance in all Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=935729, https://bugs.webkit.org/show_bug.cgi?id=195016)
+*/
+
+table {
+  text-indent: 0;
+  /* 1 */
+  border-color: inherit;
+  /* 2 */
+}
+
+/*
+Forms
+=====
+*/
+
+/**
+1. Change the font styles in all browsers.
+2. Remove the margin in Firefox and Safari.
+*/
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit;
+  /* 1 */
+  font-size: 100%;
+  /* 1 */
+  line-height: 1.15;
+  /* 1 */
+  margin: 0;
+  /* 2 */
+}
+
+/**
+Remove the inheritance of text transform in Edge and Firefox.
+1. Remove the inheritance of text transform in Firefox.
+*/
+
+button,
+select {
+  /* 1 */
+  text-transform: none;
+}
+
+/**
+Correct the inability to style clickable types in iOS and Safari.
+*/
+
+button,
+[type="button"],
+[type="reset"],
+[type="submit"] {
+  -webkit-appearance: button;
+}
+
+/**
+Remove the inner border and padding in Firefox.
+*/
+
+/**
+Restore the focus styles unset by the previous rule.
+*/
+
+/**
+Remove the additional ':invalid' styles in Firefox.
+See: https://github.com/mozilla/gecko-dev/blob/2f9eacd9d3d995c937b4251a5557d95d494c9be1/layout/style/res/forms.css#L728-L737
+*/
+
+/**
+Remove the padding so developers are not caught out when they zero out 'fieldset' elements in all browsers.
+*/
+
+legend {
+  padding: 0;
+}
+
+/**
+Add the correct vertical alignment in Chrome and Firefox.
+*/
+
+progress {
+  vertical-align: baseline;
+}
+
+/**
+Correct the cursor style of increment and decrement buttons in Safari.
+*/
+
+/**
+1. Correct the odd appearance in Chrome and Safari.
+2. Correct the outline style in Safari.
+*/
+
+[type="search"] {
+  -webkit-appearance: textfield;
+  /* 1 */
+  outline-offset: -2px;
+  /* 2 */
+}
+
+/**
+Remove the inner padding in Chrome and Safari on macOS.
+*/
+
+/**
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Change font properties to 'inherit' in Safari.
+*/
+
+/*
+Interactive
+===========
+*/
+
+/*
+Add the correct display in Chrome and Safari.
+*/
+
+summary {
+  display: list-item;
+}
+
+/**
+ * Manually forked from SUIT CSS Base: https://github.com/suitcss/base
+ * A thin layer on top of normalize.css that provides a starting point more
+ * suitable for web applications.
+ */
+
+/**
+ * Removes the default spacing and border for appropriate elements.
+ */
+
+blockquote,
+dl,
+dd,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+hr,
+figure,
+p,
+pre {
+  margin: 0;
+}
+
+button {
+  background-color: transparent;
+  background-image: none;
+}
+
+fieldset {
+  margin: 0;
+  padding: 0;
+}
+
+ol,
+ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/**
+ * Tailwind custom reset styles
+ */
+
+/**
+ * 1. Use the user's configured `sans` font-family (with Tailwind's default
+ *    sans-serif font stack as a fallback) as a sane default.
+ * 2. Use Tailwind's default "normal" line-height so the user isn't forced
+ *    to override it to ensure consistency even when using the default theme.
+ */
+
+html {
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  /* 1 */
+  line-height: 1.5;
+  /* 2 */
+}
+
+/**
+ * Inherit font-family and line-height from `html` so users can set them as
+ * a class directly on the `html` element.
+ */
+
+body {
+  font-family: inherit;
+  line-height: inherit;
+}
+
+/**
+ * 1. Prevent padding and border from affecting element width.
+ *
+ *    We used to set this in the html element and inherit from
+ *    the parent element for everything else. This caused issues
+ *    in shadow-dom-enhanced elements like <details> where the content
+ *    is wrapped by a div with box-sizing set to `content-box`.
+ *
+ *    https://github.com/mozdevs/cssremedy/issues/4
+ *
+ *
+ * 2. Allow adding a border to an element by just adding a border-width.
+ *
+ *    By default, the way the browser specifies that an element should have no
+ *    border is by setting it's border-style to `none` in the user-agent
+ *    stylesheet.
+ *
+ *    In order to easily add borders to elements by just setting the `border-width`
+ *    property, we change the default border-style for all elements to `solid`, and
+ *    use border-width to hide them instead. This way our `border` utilities only
+ *    need to set the `border-width` property instead of the entire `border`
+ *    shorthand, making our border utilities much more straightforward to compose.
+ *
+ *    https://github.com/tailwindcss/tailwindcss/pull/116
+ */
+
+*,
+::before,
+::after {
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  /* 1 */
+  border-width: 0;
+  /* 2 */
+  border-style: solid;
+  /* 2 */
+  border-color: currentColor;
+  /* 2 */
+}
+
+/*
+ * Ensure horizontal rules are visible by default
+ */
+
+hr {
+  border-top-width: 1px;
+}
+
+/**
+ * Undo the `border-style: none` reset that Normalize applies to images so that
+ * our `border-{width}` utilities have the expected effect.
+ *
+ * The Normalize reset is unnecessary for us since we default the border-width
+ * to 0 on all elements.
+ *
+ * https://github.com/tailwindcss/tailwindcss/issues/362
+ */
+
+img {
+  border-style: solid;
+}
+
+textarea {
+  resize: vertical;
+}
+
+input::-webkit-input-placeholder,
+textarea::-webkit-input-placeholder {
+  opacity: 1;
+  color: #a1a1aa;
+}
+
+input::-moz-placeholder,
+textarea::-moz-placeholder {
+  opacity: 1;
+  color: #a1a1aa;
+}
+
+input:-ms-input-placeholder,
+textarea:-ms-input-placeholder {
+  opacity: 1;
+  color: #a1a1aa;
+}
+
+input::-ms-input-placeholder,
+textarea::-ms-input-placeholder {
+  opacity: 1;
+  color: #a1a1aa;
+}
+
+input::placeholder,
+textarea::placeholder {
+  opacity: 1;
+  color: #a1a1aa;
+}
+
+button,
+[role="button"] {
+  cursor: pointer;
+}
+
+/**
+ * Override legacy focus reset from Normalize with modern Firefox focus styles.
+ *
+ * This is actually an improvement over the new defaults in Firefox in our testing,
+ * as it triggers the better focus styles even for links, which still use a dotted
+ * outline in Firefox by default.
+ */
+
+table {
+  border-collapse: collapse;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+/**
+ * Reset links to optimize for opt-in styling instead of
+ * opt-out.
+ */
+
+a {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+/**
+ * Reset form element properties that are easy to forget to
+ * style explicitly so you don't inadvertently introduce
+ * styles that deviate from your design system. These styles
+ * supplement a partial reset that is already applied by
+ * normalize.css.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  padding: 0;
+  line-height: inherit;
+  color: inherit;
+}
+
+/**
+ * Use the configured 'mono' font family for elements that
+ * are expected to be rendered with a monospace font, falling
+ * back to the system monospace stack if there is no configured
+ * 'mono' font family.
+ */
+
+pre,
+code,
+kbd,
+samp {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+}
+
+/**
+ * 1. Make replaced elements `display: block` by default as that's
+ *    the behavior you want almost all of the time. Inspired by
+ *    CSS Remedy, with `svg` added as well.
+ *
+ *    https://github.com/mozdevs/cssremedy/issues/14
+ * 
+ * 2. Add `vertical-align: middle` to align replaced elements more
+ *    sensibly by default when overriding `display` by adding a
+ *    utility like `inline`.
+ *
+ *    This can trigger a poorly considered linting error in some
+ *    tools but is included by design.
+ * 
+ *    https://github.com/jensimmons/cssremedy/issues/14#issuecomment-634934210
+ */
+
+img,
+svg,
+video,
+canvas,
+audio,
+iframe,
+embed,
+object {
+  display: block;
+  /* 1 */
+  vertical-align: middle;
+  /* 2 */
+}
+
+/**
+ * Constrain images and videos to the parent width and preserve
+ * their intrinsic aspect ratio.
+ *
+ * https://github.com/mozdevs/cssremedy/issues/14
+ */
+
+img,
+video {
+  max-width: 100%;
+  height: auto;
+}
+
+/**
+ * Ensure the default browser behavior of the `hidden` attribute.
+ */
+
+[hidden] {
+  display: none;
+}
+
+*,
+::before,
+::after {
+  border-color: currentColor;
+}
+
+h1 {
+  font-size: 2.25rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+h2 {
+  font-size: 2.125rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+h3 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+h4 {
+  font-size: 1.875rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+h5 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+h6 {
+  font-size: 1.625rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.container {
+  width: 100%;
+}
+
+@media (min-width: 350px) {
+  .container {
+    max-width: 350px;
+  }
+}
+
+@media (min-width: 640px) {
+  .container {
+    max-width: 640px;
+  }
+}
+
+@media (min-width: 768px) {
+  .container {
+    max-width: 768px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .container {
+    max-width: 1024px;
+  }
+}
+
+@media (min-width: 1280px) {
+  .container {
+    max-width: 1280px;
+  }
+}
+
+@media (min-width: 1536px) {
+  .container {
+    max-width: 1536px;
+  }
+}
+
+.btn-primary {
+  min-height: 2.75rem;
+  padding: 0 2rem;
+  border-radius: 0.5rem;
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(#8631a0),
+    to(#360b4c)
+  );
+  background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  -webkit-box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.1);
+  box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.1);
+  color: #ffffff;
+  font-size: 1rem;
+  font-weight: 700;
+  -webkit-transition: all 200ms cubic-bezier(0.4, 0, 1, 1);
+  transition: all 200ms cubic-bezier(0.4, 0, 1, 1);
+}
+
+.btn-primary:hover {
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(#b964d3),
+    to(#360b4c)
+  );
+  background-image: linear-gradient(#b964d3 0%, #360b4c 100%);
+}
+
+.btn-primary:focus {
+  -webkit-box-shadow: 0px 0px 0px 2px #ffffff,
+    0px 0px 0px 4px rgba(138, 53, 183, 0.7), 0px 1px 2px 0px rgba(0, 0, 0, 0.1);
+  box-shadow: 0px 0px 0px 2px #ffffff, 0px 0px 0px 4px rgba(138, 53, 183, 0.7),
+    0px 1px 2px 0px rgba(0, 0, 0, 0.1);
+}
+
+.btn-primary:disabled {
+  background-image: none;
+  background-color: #7b6f7f;
+  color: #ffffff;
+  cursor: not-allowed;
+}
+
+.btn-outline {
+  min-height: 2.75rem;
+  padding: 0 2rem;
+  border: 1px solid #c7c3c8;
+  border-radius: 0.5rem;
+  background-color: #ffffff;
+  color: #6c6d7c;
+  font-size: 1rem;
+  font-weight: 700;
+  -webkit-transition: all 200ms cubic-bezier(0.4, 0, 1, 1);
+  transition: all 200ms cubic-bezier(0.4, 0, 1, 1);
+}
+
+.btn-outline:hover {
+  border: 1px solid #949095;
+}
+
+.btn-outline:focus {
+  -webkit-box-shadow: 0px 0px 0px 2px rgba(138, 53, 183, 0.7);
+  box-shadow: 0px 0px 0px 2px rgba(138, 53, 183, 0.7);
+}
+
+.input-container {
+  position: relative;
+  margin-bottom: 1.5rem;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: flex-start;
+  width: 100%;
+}
+
+.input-container input {
+  height: 3.75rem;
+  padding: 26px 4rem 10px 1rem;
+  background-color: #eeeaee;
+  width: 100%;
+  border: none;
+  border-bottom: 2px solid #949095;
+  border-radius: 6px 6px 0px 0px;
+  color: #190c21;
+}
+
+.input-container input:focus {
+  border-color: #8a35b7;
+}
+
+.input-container input:invalid {
+  border-color: #d24343;
+}
+
+.input-container input:invalid ~ img {
+  visibility: visible;
+}
+
+.input-container input::-webkit-input-placeholder {
+  visibility: hidden;
+}
+
+.input-container input::-moz-placeholder {
+  visibility: hidden;
+}
+
+.input-container input:-ms-input-placeholder {
+  visibility: hidden;
+}
+
+.input-container input::-ms-input-placeholder {
+  visibility: hidden;
+}
+
+.input-container input::placeholder {
+  visibility: hidden;
+}
+
+.input-container input:focus::-webkit-input-placeholder {
+  visibility: visible;
+  color: #6c6d7c;
+  font-size: 1rem;
+}
+
+.input-container input:focus::-moz-placeholder {
+  visibility: visible;
+  color: #6c6d7c;
+  font-size: 1rem;
+}
+
+.input-container input:focus:-ms-input-placeholder {
+  visibility: visible;
+  color: #6c6d7c;
+  font-size: 1rem;
+}
+
+.input-container input:focus::-ms-input-placeholder {
+  visibility: visible;
+  color: #6c6d7c;
+  font-size: 1rem;
+}
+
+.input-container input:focus::placeholder {
+  visibility: visible;
+  color: #6c6d7c;
+  font-size: 1rem;
+}
+
+.input-container input:not(:focus):not(:-moz-placeholder-shown) + .input-label {
+  top: 5px;
+  font-size: 0.875rem;
+  margin-bottom: 2rem;
+}
+
+.input-container input:not(:focus):not(:-ms-input-placeholder) + .input-label {
+  top: 5px;
+  font-size: 0.875rem;
+  margin-bottom: 2rem;
+}
+
+.input-container input:focus + .input-label,
+.input-container input:not(:focus):not(:placeholder-shown) + .input-label {
+  top: 5px;
+  font-size: 0.875rem;
+  margin-bottom: 2rem;
+}
+
+.input-container .input-label {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #190c21;
+  position: absolute;
+  padding-left: 1rem;
+  -webkit-transition: top 0.2s;
+  transition: top 0.2s;
+  top: 17px;
+}
+
+.input-container .input-wordlimit {
+  position: absolute;
+  height: 3.5rem;
+  right: 1rem;
+  color: #6c6d7c;
+  font-size: 0.875rem;
+  top: 1px;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.input-container .input-helper {
+  color: #6c6d7c;
+  font-size: 0.875rem;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-top: 5px;
+}
+
+.input-container .fader {
+  position: absolute;
+  top: 1px;
+  right: 4rem;
+  background: -webkit-gradient(
+    linear,
+    left top,
+    right top,
+    from(rgba(238, 234, 238, 0)),
+    to(rgb(238, 234, 238))
+  );
+  background: linear-gradient(
+    90deg,
+    rgba(238, 234, 238, 0) 0%,
+    rgb(238, 234, 238) 100%
+  );
+  border-radius: 0px 4px 0px 0px;
+  height: 3.5rem;
+  width: 68px;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.input-container img {
+  visibility: hidden;
+  position: absolute;
+  top: 18px;
+  right: 0.75rem;
+}
+
+.underline-blue {
+  border-bottom: 2px solid #2883fb;
+  padding-bottom: 2px;
+}
+
+.underline-white {
+  padding-bottom: 2px;
+}
+
+.underline-white:not(:focus):not(:focus-within):hover {
+  border-bottom: 1px solid #ffffff;
+  padding-bottom: 1px;
+}
+
+.error-notification {
+  background-color: #d24343;
+  top: 2rem;
+  position: absolute;
+  border-radius: 0.75rem;
+  z-index: 10;
+  max-width: 48rem;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  vertical-align: middle;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 1rem 1.25rem;
+  color: #f4f1f5;
+}
+
+.nocredentialCard {
+  width: 342px;
+  height: 152px;
+}
+
+@media (min-width: 768px) {
+  .nocredentialCard {
+    width: 384px;
+  }
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+.visible {
+  visibility: visible;
+}
+
+.invisible {
+  visibility: hidden;
+}
+
+.static {
+  position: static;
+}
+
+.fixed {
+  position: fixed;
+}
+
+.absolute {
+  position: absolute;
+}
+
+.relative {
+  position: relative;
+}
+
+.sticky {
+  position: sticky;
+}
+
+.inset-0 {
+  top: 0px;
+  right: 0px;
+  bottom: 0px;
+  left: 0px;
+}
+
+.top-0 {
+  top: 0px;
+}
+
+.top-3 {
+  top: 0.75rem;
+}
+
+.top-5 {
+  top: 1.25rem;
+}
+
+.top-14 {
+  top: 3.5rem;
+}
+
+.right-0 {
+  right: 0px;
+}
+
+.right-4 {
+  right: 1rem;
+}
+
+.bottom-0 {
+  bottom: 0px;
+}
+
+.bottom-1 {
+  bottom: 0.25rem;
+}
+
+.left-1 {
+  left: 0.25rem;
+}
+
+.left-5 {
+  left: 1.25rem;
+}
+
+.left-6 {
+  left: 1.5rem;
+}
+
+.z-10 {
+  z-index: 10;
+}
+
+.z-20 {
+  z-index: 20;
+}
+
+.z-30 {
+  z-index: 30;
+}
+
+.z-50 {
+  z-index: 50;
+}
+
+.order-first {
+  -webkit-box-ordinal-group: -9998;
+  -ms-flex-order: -9999;
+  order: -9999;
+}
+
+.order-last {
+  -webkit-box-ordinal-group: 10000;
+  -ms-flex-order: 9999;
+  order: 9999;
+}
+
+.col-span-1 {
+  grid-column: span 1 / span 1;
+}
+
+.col-span-2 {
+  grid-column: span 2 / span 2;
+}
+
+.col-start-1 {
+  grid-column-start: 1;
+}
+
+.col-end-2 {
+  grid-column-end: 2;
+}
+
+.m-0 {
+  margin: 0px;
+}
+
+.m-1 {
+  margin: 0.25rem;
+}
+
+.m-2 {
+  margin: 0.5rem;
+}
+
+.m-3 {
+  margin: 0.75rem;
+}
+
+.m-4 {
+  margin: 1rem;
+}
+
+.m-5 {
+  margin: 1.25rem;
+}
+
+.m-6 {
+  margin: 1.5rem;
+}
+
+.mx-0 {
+  margin-left: 0px;
+  margin-right: 0px;
+}
+
+.mx-1 {
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+}
+
+.mx-2 {
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+}
+
+.mx-3 {
+  margin-left: 0.75rem;
+  margin-right: 0.75rem;
+}
+
+.mx-4 {
+  margin-left: 1rem;
+  margin-right: 1rem;
+}
+
+.mx-5 {
+  margin-left: 1.25rem;
+  margin-right: 1.25rem;
+}
+
+.mx-6 {
+  margin-left: 1.5rem;
+  margin-right: 1.5rem;
+}
+
+.mx-8 {
+  margin-left: 2rem;
+  margin-right: 2rem;
+}
+
+.mx-10 {
+  margin-left: 2.5rem;
+  margin-right: 2.5rem;
+}
+
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.my-0 {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.my-1 {
+  margin-top: 0.25rem;
+  margin-bottom: 0.25rem;
+}
+
+.my-2 {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.my-3 {
+  margin-top: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.my-4 {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+.my-5 {
+  margin-top: 1.25rem;
+  margin-bottom: 1.25rem;
+}
+
+.my-6 {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.my-8 {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
+.mt-0 {
+  margin-top: 0px;
+}
+
+.mt-1 {
+  margin-top: 0.25rem;
+}
+
+.mt-2 {
+  margin-top: 0.5rem;
+}
+
+.mt-3 {
+  margin-top: 0.75rem;
+}
+
+.mt-4 {
+  margin-top: 1rem;
+}
+
+.mt-5 {
+  margin-top: 1.25rem;
+}
+
+.mt-6 {
+  margin-top: 1.5rem;
+}
+
+.mt-8 {
+  margin-top: 2rem;
+}
+
+.mt-12 {
+  margin-top: 3rem;
+}
+
+.mt-13 {
+  margin-top: 3.25rem;
+}
+
+.mt-20 {
+  margin-top: 5rem;
+}
+
+.mt-auto {
+  margin-top: auto;
+}
+
+.-mt-12 {
+  margin-top: -3rem;
+}
+
+.mr-0 {
+  margin-right: 0px;
+}
+
+.mr-1 {
+  margin-right: 0.25rem;
+}
+
+.mr-2 {
+  margin-right: 0.5rem;
+}
+
+.mr-3 {
+  margin-right: 0.75rem;
+}
+
+.mr-4 {
+  margin-right: 1rem;
+}
+
+.mr-5 {
+  margin-right: 1.25rem;
+}
+
+.mr-6 {
+  margin-right: 1.5rem;
+}
+
+.mb-0 {
+  margin-bottom: 0px;
+}
+
+.mb-1 {
+  margin-bottom: 0.25rem;
+}
+
+.mb-2 {
+  margin-bottom: 0.5rem;
+}
+
+.mb-3 {
+  margin-bottom: 0.75rem;
+}
+
+.mb-4 {
+  margin-bottom: 1rem;
+}
+
+.mb-5 {
+  margin-bottom: 1.25rem;
+}
+
+.mb-6 {
+  margin-bottom: 1.5rem;
+}
+
+.mb-8 {
+  margin-bottom: 2rem;
+}
+
+.mb-10 {
+  margin-bottom: 2.5rem;
+}
+
+.mb-12 {
+  margin-bottom: 3rem;
+}
+
+.ml-3 {
+  margin-left: 0.75rem;
+}
+
+.ml-4 {
+  margin-left: 1rem;
+}
+
+.block {
+  display: block;
+}
+
+.inline-block {
+  display: inline-block;
+}
+
+.inline {
+  display: inline;
+}
+
+.flex {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.inline-flex {
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.table {
+  display: table;
+}
+
+.grid {
+  display: grid;
+}
+
+.contents {
+  display: contents;
+}
+
+.hidden {
+  display: none;
+}
+
+.h-3 {
+  height: 0.75rem;
+}
+
+.h-5 {
+  height: 1.25rem;
+}
+
+.h-6 {
+  height: 1.5rem;
+}
+
+.h-8 {
+  height: 2rem;
+}
+
+.h-10 {
+  height: 2.5rem;
+}
+
+.h-11 {
+  height: 2.75rem;
+}
+
+.h-12 {
+  height: 3rem;
+}
+
+.h-14 {
+  height: 3.5rem;
+}
+
+.h-15 {
+  height: 3.75rem;
+}
+
+.h-16 {
+  height: 4rem;
+}
+
+.h-20 {
+  height: 5rem;
+}
+
+.h-24 {
+  height: 6rem;
+}
+
+.h-48 {
+  height: 12rem;
+}
+
+.h-80 {
+  height: 20rem;
+}
+
+.h-auto {
+  height: auto;
+}
+
+.h-px {
+  height: 1px;
+}
+
+.h-full {
+  height: 100%;
+}
+
+.h-screen {
+  height: 100vh;
+}
+
+.max-h-6 {
+  max-height: 1.5rem;
+}
+
+.max-h-screen {
+  max-height: 100vh;
+}
+
+.min-h-screen {
+  min-height: 100vh;
+}
+
+.w-6 {
+  width: 1.5rem;
+}
+
+.w-8 {
+  width: 2rem;
+}
+
+.w-10 {
+  width: 2.5rem;
+}
+
+.w-11 {
+  width: 2.75rem;
+}
+
+.w-12 {
+  width: 3rem;
+}
+
+.w-14 {
+  width: 3.5rem;
+}
+
+.w-15 {
+  width: 3.75rem;
+}
+
+.w-20 {
+  width: 5rem;
+}
+
+.w-48 {
+  width: 12rem;
+}
+
+.w-1\/2 {
+  width: 50%;
+}
+
+.w-full {
+  width: 100%;
+}
+
+.w-screen {
+  width: 100vw;
+}
+
+.min-w-80 {
+  min-width: 20rem;
+}
+
+.max-w-xs {
+  max-width: 20rem;
+}
+
+.max-w-md {
+  max-width: 28rem;
+}
+
+.max-w-lg {
+  max-width: 32rem;
+}
+
+.max-w-xl {
+  max-width: 36rem;
+}
+
+.max-w-3xl {
+  max-width: 48rem;
+}
+
+.max-w-7xl {
+  max-width: 80rem;
+}
+
+.max-w-full {
+  max-width: 100%;
+}
+
+.flex-1 {
+  -webkit-box-flex: 1;
+  -ms-flex: 1 1 0%;
+  flex: 1 1 0%;
+}
+
+.flex-auto {
+  -webkit-box-flex: 1;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+}
+
+.flex-none {
+  -webkit-box-flex: 0;
+  -ms-flex: none;
+  flex: none;
+}
+
+.flex-shrink {
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+
+.flex-grow {
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.transform {
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  -webkit-transform: translateX(var(--tw-translate-x))
+    translateY(var(--tw-translate-y)) rotate(var(--tw-rotate))
+    skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x))
+    scaleY(var(--tw-scale-y));
+  transform: translateX(var(--tw-translate-x)) translateY(var(--tw-translate-y))
+    rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
+    scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.rotate-45 {
+  --tw-rotate: 45deg;
+}
+
+.rotate-90 {
+  --tw-rotate: 90deg;
+}
+
+.rotate-180 {
+  --tw-rotate: 180deg;
+}
+
+@-webkit-keyframes spin {
+  to {
+    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes spin {
+  to {
+    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+@-webkit-keyframes ping {
+  75%,
+  100% {
+    -webkit-transform: scale(2);
+    transform: scale(2);
+    opacity: 0;
+  }
+}
+
+@keyframes ping {
+  75%,
+  100% {
+    -webkit-transform: scale(2);
+    transform: scale(2);
+    opacity: 0;
+  }
+}
+
+@-webkit-keyframes pulse {
+  50% {
+    opacity: 0.5;
+  }
+}
+
+@keyframes pulse {
+  50% {
+    opacity: 0.5;
+  }
+}
+
+@-webkit-keyframes bounce {
+  0%,
+  100% {
+    -webkit-transform: translateY(-25%);
+    transform: translateY(-25%);
+    -webkit-animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+    animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+  }
+
+  50% {
+    -webkit-transform: none;
+    transform: none;
+    -webkit-animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  }
+}
+
+@keyframes bounce {
+  0%,
+  100% {
+    -webkit-transform: translateY(-25%);
+    transform: translateY(-25%);
+    -webkit-animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+    animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+  }
+
+  50% {
+    -webkit-transform: none;
+    transform: none;
+    -webkit-animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  }
+}
+
+.animate-spin {
+  -webkit-animation: spin 1s linear infinite;
+  animation: spin 1s linear infinite;
+}
+
+.cursor-pointer {
+  cursor: pointer;
+}
+
+.resize {
+  resize: both;
+}
+
+.list-inside {
+  list-style-position: inside;
+}
+
+.appearance-none {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.grid-cols-1 {
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+.grid-cols-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.flex-row {
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.flex-col {
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.flex-wrap {
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+.content-center {
+  -ms-flex-line-pack: center;
+  align-content: center;
+}
+
+.items-start {
+  -webkit-box-align: start;
+  -ms-flex-align: start;
+  align-items: flex-start;
+}
+
+.items-center {
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.justify-start {
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.justify-end {
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.justify-center {
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.justify-between {
+  -webkit-box-pack: justify;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.gap-4 {
+  gap: 1rem;
+}
+
+.gap-8 {
+  gap: 2rem;
+}
+
+.gap-y-8 {
+  row-gap: 2rem;
+}
+
+.space-x-2 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(0.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
+.space-y-3 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.75rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.75rem * var(--tw-space-y-reverse));
+}
+
+.space-y-5 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(1.25rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(1.25rem * var(--tw-space-y-reverse));
+}
+
+.divide-x > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-x-reverse: 0;
+  border-right-width: calc(1px * var(--tw-divide-x-reverse));
+  border-left-width: calc(1px * calc(1 - var(--tw-divide-x-reverse)));
+}
+
+.divide-y > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-y-reverse: 0;
+  border-top-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
+  border-bottom-width: calc(1px * var(--tw-divide-y-reverse));
+}
+
+.divide-neutrals-medium > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 1;
+  border-color: rgba(108, 109, 124, var(--tw-divide-opacity));
+}
+
+.divide-opacity-25 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 0.25;
+}
+
+.overflow-hidden {
+  overflow: hidden;
+}
+
+.overflow-scroll {
+  overflow: scroll;
+}
+
+.overflow-y-auto {
+  overflow-y: auto;
+}
+
+.truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.overflow-ellipsis {
+  text-overflow: ellipsis;
+}
+
+.whitespace-nowrap {
+  white-space: nowrap;
+}
+
+.break-words {
+  overflow-wrap: break-word;
+}
+
+.rounded-sm {
+  border-radius: 0.125rem;
+}
+
+.rounded {
+  border-radius: 0.25rem;
+}
+
+.rounded-md {
+  border-radius: 0.375rem;
+}
+
+.rounded-lg {
+  border-radius: 0.5rem;
+}
+
+.rounded-xl {
+  border-radius: 0.75rem;
+}
+
+.rounded-2xl {
+  border-radius: 1rem;
+}
+
+.rounded-3xl {
+  border-radius: 1.5rem;
+}
+
+.rounded-full {
+  border-radius: 9999px;
+}
+
+.focus\:rounded:focus {
+  border-radius: 0.25rem;
+}
+
+.rounded-t-none {
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+}
+
+.rounded-t-lg {
+  border-top-left-radius: 0.5rem;
+  border-top-right-radius: 0.5rem;
+}
+
+.rounded-b {
+  border-bottom-right-radius: 0.25rem;
+  border-bottom-left-radius: 0.25rem;
+}
+
+.rounded-b-lg {
+  border-bottom-right-radius: 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+}
+
+.rounded-b-xl {
+  border-bottom-right-radius: 0.75rem;
+  border-bottom-left-radius: 0.75rem;
+}
+
+.rounded-b-2xl {
+  border-bottom-right-radius: 1rem;
+  border-bottom-left-radius: 1rem;
+}
+
+.border-0 {
+  border-width: 0px;
+}
+
+.border-8 {
+  border-width: 8px;
+}
+
+.border {
+  border-width: 1px;
+}
+
+.border-t-0 {
+  border-top-width: 0px;
+}
+
+.border-t {
+  border-top-width: 1px;
+}
+
+.border-b-2 {
+  border-bottom-width: 2px;
+}
+
+.border-b {
+  border-bottom-width: 1px;
+}
+
+.border-dotted {
+  border-style: dotted;
+}
+
+.border-none {
+  border-style: none;
+}
+
+.border-neutrals-black {
+  --tw-border-opacity: 1;
+  border-color: rgba(0, 0, 0, var(--tw-border-opacity));
+}
+
+.border-neutrals-chatelle {
+  --tw-border-opacity: 1;
+  border-color: rgba(199, 195, 200, var(--tw-border-opacity));
+}
+
+.border-neutrals-dark {
+  --tw-border-opacity: 1;
+  border-color: rgba(25, 12, 33, var(--tw-border-opacity));
+}
+
+.border-neutrals-lilacSoft {
+  --tw-border-opacity: 1;
+  border-color: rgba(237, 234, 238, var(--tw-border-opacity));
+}
+
+.border-neutrals-thistle {
+  --tw-border-opacity: 1;
+  border-color: rgba(219, 215, 220, var(--tw-border-opacity));
+}
+
+.hover\:border-transparent:hover {
+  border-color: transparent;
+}
+
+.hover\:border-neutrals-chatelle:hover {
+  --tw-border-opacity: 1;
+  border-color: rgba(199, 195, 200, var(--tw-border-opacity));
+}
+
+.hover\:border-neutrals-mountainMist-light:hover {
+  --tw-border-opacity: 1;
+  border-color: rgba(148, 144, 149, var(--tw-border-opacity));
+}
+
+.focus\:border-neutrals-chatelle:focus {
+  --tw-border-opacity: 1;
+  border-color: rgba(199, 195, 200, var(--tw-border-opacity));
+}
+
+.border-opacity-10 {
+  --tw-border-opacity: 0.1;
+}
+
+.border-opacity-20 {
+  --tw-border-opacity: 0.2;
+}
+
+.bg-transparent {
+  background-color: transparent;
+}
+
+.bg-neutrals-black {
+  --tw-bg-opacity: 1;
+  background-color: rgba(0, 0, 0, var(--tw-bg-opacity));
+}
+
+.bg-neutrals-dark {
+  --tw-bg-opacity: 1;
+  background-color: rgba(25, 12, 33, var(--tw-bg-opacity));
+}
+
+.bg-neutrals-lilacSoft {
+  --tw-bg-opacity: 1;
+  background-color: rgba(237, 234, 238, var(--tw-bg-opacity));
+}
+
+.bg-neutrals-magnolia {
+  --tw-bg-opacity: 1;
+  background-color: rgba(251, 248, 252, var(--tw-bg-opacity));
+}
+
+.bg-neutrals-moist {
+  --tw-bg-opacity: 1;
+  background-color: rgba(245, 244, 246, var(--tw-bg-opacity));
+}
+
+.bg-neutrals-mischka {
+  --tw-bg-opacity: 1;
+  background-color: rgba(220, 218, 221, var(--tw-bg-opacity));
+}
+
+.bg-neutrals-mobster {
+  --tw-bg-opacity: 1;
+  background-color: rgba(123, 111, 127, var(--tw-bg-opacity));
+}
+
+.bg-neutrals-softWhite {
+  --tw-bg-opacity: 1;
+  background-color: rgba(244, 241, 245, var(--tw-bg-opacity));
+}
+
+.bg-neutrals-thistle {
+  --tw-bg-opacity: 1;
+  background-color: rgba(219, 215, 220, var(--tw-bg-opacity));
+}
+
+.bg-neutrals-white {
+  --tw-bg-opacity: 1;
+  background-color: rgba(255, 255, 255, var(--tw-bg-opacity));
+}
+
+.bg-neutrals-whiteLilac {
+  --tw-bg-opacity: 1;
+  background-color: rgba(228, 225, 229, var(--tw-bg-opacity));
+}
+
+.bg-primary-valencia {
+  --tw-bg-opacity: 1;
+  background-color: rgba(210, 67, 67, var(--tw-bg-opacity));
+}
+
+.bg-gray-light {
+  --tw-bg-opacity: 1;
+  background-color: rgba(244, 241, 245, var(--tw-bg-opacity));
+}
+
+.hover\:bg-neutrals-softWhite:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgba(244, 241, 245, var(--tw-bg-opacity));
+}
+
+.focus\:bg-neutrals-mischka:focus {
+  --tw-bg-opacity: 1;
+  background-color: rgba(220, 218, 221, var(--tw-bg-opacity));
+}
+
+.bg-opacity-25 {
+  --tw-bg-opacity: 0.25;
+}
+
+.bg-opacity-40 {
+  --tw-bg-opacity: 0.4;
+}
+
+.bg-opacity-50 {
+  --tw-bg-opacity: 0.5;
+}
+
+.group:hover .group-hover\:bg-opacity-60 {
+  --tw-bg-opacity: 0.6;
+}
+
+.bg-gradient-to-t {
+  background-image: -webkit-gradient(
+    linear,
+    left bottom,
+    left top,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to top, var(--tw-gradient-stops));
+}
+
+.bg-gradient-to-tr {
+  background-image: -webkit-gradient(
+    linear,
+    left bottom,
+    right top,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+}
+
+.bg-gradient-to-r {
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    right top,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to right, var(--tw-gradient-stops));
+}
+
+.bg-gradient-to-br {
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    right bottom,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to bottom right, var(--tw-gradient-stops));
+}
+
+.bg-gradient-to-b {
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+}
+
+.bg-gradient-to-bl {
+  background-image: -webkit-gradient(
+    linear,
+    right top,
+    left bottom,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+}
+
+.bg-gradient-to-l {
+  background-image: -webkit-gradient(
+    linear,
+    right top,
+    left top,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to left, var(--tw-gradient-stops));
+}
+
+.bg-gradient-to-tl {
+  background-image: -webkit-gradient(
+    linear,
+    right bottom,
+    left top,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+}
+
+.bg-gradient-boatBlue {
+  background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+}
+
+.bg-gradient-cobalt {
+  background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+}
+
+.bg-gradient-dark {
+  background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+}
+
+.bg-gradient-harold {
+  background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+}
+
+.bg-gradient-full {
+  background-image: linear-gradient(
+    -225deg,
+    #ec857c 0%,
+    #cc3566 26%,
+    #df7f75 47%,
+    #90399e 66%,
+    #5d5cbd 83%,
+    #2f97d9 100%
+  );
+}
+
+.bg-gradient-green {
+  background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+}
+
+.bg-gradient-pink {
+  background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+}
+
+.bg-gradient-purple {
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(#8631a0),
+    to(#360b4c)
+  );
+  background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+}
+
+.bg-gradient-red {
+  background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+}
+
+.bg-onboarding-sm {
+  background-image: url("~@/assets/img/onboarding-bg-sm.svg");
+}
+
+.bg-onboarding-flare-lg {
+  background-image: url("~@/assets/img/onboarding-flare-lg.png");
+}
+
+.focus-within\:bg-gradient-to-t:focus-within {
+  background-image: -webkit-gradient(
+    linear,
+    left bottom,
+    left top,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to top, var(--tw-gradient-stops));
+}
+
+.focus-within\:bg-gradient-to-tr:focus-within {
+  background-image: -webkit-gradient(
+    linear,
+    left bottom,
+    right top,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+}
+
+.focus-within\:bg-gradient-to-r:focus-within {
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    right top,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to right, var(--tw-gradient-stops));
+}
+
+.focus-within\:bg-gradient-to-br:focus-within {
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    right bottom,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to bottom right, var(--tw-gradient-stops));
+}
+
+.focus-within\:bg-gradient-to-b:focus-within {
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+}
+
+.focus-within\:bg-gradient-to-bl:focus-within {
+  background-image: -webkit-gradient(
+    linear,
+    right top,
+    left bottom,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+}
+
+.focus-within\:bg-gradient-to-l:focus-within {
+  background-image: -webkit-gradient(
+    linear,
+    right top,
+    left top,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to left, var(--tw-gradient-stops));
+}
+
+.focus-within\:bg-gradient-to-tl:focus-within {
+  background-image: -webkit-gradient(
+    linear,
+    right bottom,
+    left top,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+}
+
+.focus-within\:bg-gradient-boatBlue:focus-within {
+  background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+}
+
+.focus-within\:bg-gradient-cobalt:focus-within {
+  background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+}
+
+.focus-within\:bg-gradient-dark:focus-within {
+  background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+}
+
+.focus-within\:bg-gradient-harold:focus-within {
+  background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+}
+
+.focus-within\:bg-gradient-full:focus-within {
+  background-image: linear-gradient(
+    -225deg,
+    #ec857c 0%,
+    #cc3566 26%,
+    #df7f75 47%,
+    #90399e 66%,
+    #5d5cbd 83%,
+    #2f97d9 100%
+  );
+}
+
+.focus-within\:bg-gradient-green:focus-within {
+  background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+}
+
+.focus-within\:bg-gradient-pink:focus-within {
+  background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+}
+
+.focus-within\:bg-gradient-purple:focus-within {
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(#8631a0),
+    to(#360b4c)
+  );
+  background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+}
+
+.focus-within\:bg-gradient-red:focus-within {
+  background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+}
+
+.hover\:bg-gradient-to-t:hover {
+  background-image: -webkit-gradient(
+    linear,
+    left bottom,
+    left top,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to top, var(--tw-gradient-stops));
+}
+
+.hover\:bg-gradient-to-tr:hover {
+  background-image: -webkit-gradient(
+    linear,
+    left bottom,
+    right top,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+}
+
+.hover\:bg-gradient-to-r:hover {
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    right top,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to right, var(--tw-gradient-stops));
+}
+
+.hover\:bg-gradient-to-br:hover {
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    right bottom,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to bottom right, var(--tw-gradient-stops));
+}
+
+.hover\:bg-gradient-to-b:hover {
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+}
+
+.hover\:bg-gradient-to-bl:hover {
+  background-image: -webkit-gradient(
+    linear,
+    right top,
+    left bottom,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+}
+
+.hover\:bg-gradient-to-l:hover {
+  background-image: -webkit-gradient(
+    linear,
+    right top,
+    left top,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to left, var(--tw-gradient-stops));
+}
+
+.hover\:bg-gradient-to-tl:hover {
+  background-image: -webkit-gradient(
+    linear,
+    right bottom,
+    left top,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+}
+
+.hover\:bg-gradient-boatBlue:hover {
+  background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+}
+
+.hover\:bg-gradient-cobalt:hover {
+  background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+}
+
+.hover\:bg-gradient-dark:hover {
+  background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+}
+
+.hover\:bg-gradient-harold:hover {
+  background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+}
+
+.hover\:bg-gradient-full:hover {
+  background-image: linear-gradient(
+    -225deg,
+    #ec857c 0%,
+    #cc3566 26%,
+    #df7f75 47%,
+    #90399e 66%,
+    #5d5cbd 83%,
+    #2f97d9 100%
+  );
+}
+
+.hover\:bg-gradient-green:hover {
+  background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+}
+
+.hover\:bg-gradient-pink:hover {
+  background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+}
+
+.hover\:bg-gradient-purple:hover {
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(#8631a0),
+    to(#360b4c)
+  );
+  background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+}
+
+.hover\:bg-gradient-red:hover {
+  background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+}
+
+.disabled\:bg-gradient-to-t:disabled {
+  background-image: -webkit-gradient(
+    linear,
+    left bottom,
+    left top,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to top, var(--tw-gradient-stops));
+}
+
+.disabled\:bg-gradient-to-tr:disabled {
+  background-image: -webkit-gradient(
+    linear,
+    left bottom,
+    right top,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+}
+
+.disabled\:bg-gradient-to-r:disabled {
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    right top,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to right, var(--tw-gradient-stops));
+}
+
+.disabled\:bg-gradient-to-br:disabled {
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    right bottom,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to bottom right, var(--tw-gradient-stops));
+}
+
+.disabled\:bg-gradient-to-b:disabled {
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+}
+
+.disabled\:bg-gradient-to-bl:disabled {
+  background-image: -webkit-gradient(
+    linear,
+    right top,
+    left bottom,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+}
+
+.disabled\:bg-gradient-to-l:disabled {
+  background-image: -webkit-gradient(
+    linear,
+    right top,
+    left top,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to left, var(--tw-gradient-stops));
+}
+
+.disabled\:bg-gradient-to-tl:disabled {
+  background-image: -webkit-gradient(
+    linear,
+    right bottom,
+    left top,
+    from(var(--tw-gradient-stops))
+  );
+  background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+}
+
+.disabled\:bg-gradient-boatBlue:disabled {
+  background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+}
+
+.disabled\:bg-gradient-cobalt:disabled {
+  background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+}
+
+.disabled\:bg-gradient-dark:disabled {
+  background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+}
+
+.disabled\:bg-gradient-harold:disabled {
+  background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+}
+
+.disabled\:bg-gradient-full:disabled {
+  background-image: linear-gradient(
+    -225deg,
+    #ec857c 0%,
+    #cc3566 26%,
+    #df7f75 47%,
+    #90399e 66%,
+    #5d5cbd 83%,
+    #2f97d9 100%
+  );
+}
+
+.disabled\:bg-gradient-green:disabled {
+  background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+}
+
+.disabled\:bg-gradient-pink:disabled {
+  background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+}
+
+.disabled\:bg-gradient-purple:disabled {
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(#8631a0),
+    to(#360b4c)
+  );
+  background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+}
+
+.disabled\:bg-gradient-red:disabled {
+  background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+}
+
+.from-neutrals-black {
+  --tw-gradient-from: #000000;
+  --tw-gradient-stops: var(--tw-gradient-from),
+    var(--tw-gradient-to, rgba(0, 0, 0, 0));
+}
+
+.from-haiti {
+  --tw-gradient-from: #261131;
+  --tw-gradient-stops: var(--tw-gradient-from),
+    var(--tw-gradient-to, rgba(38, 17, 49, 0));
+}
+
+.focus-within\:from-neutrals-black:focus-within {
+  --tw-gradient-from: #000000;
+  --tw-gradient-stops: var(--tw-gradient-from),
+    var(--tw-gradient-to, rgba(0, 0, 0, 0));
+}
+
+.hover\:from-neutrals-black:hover {
+  --tw-gradient-from: #000000;
+  --tw-gradient-stops: var(--tw-gradient-from),
+    var(--tw-gradient-to, rgba(0, 0, 0, 0));
+}
+
+.to-jagger {
+  --tw-gradient-to: #360b4c;
+}
+
+.bg-scroll {
+  background-attachment: scroll;
+}
+
+.bg-no-repeat {
+  background-repeat: no-repeat;
+}
+
+.fill-current {
+  fill: currentColor;
+}
+
+.object-contain {
+  -o-object-fit: contain;
+  object-fit: contain;
+}
+
+.object-none {
+  -o-object-fit: none;
+  object-fit: none;
+}
+
+.object-scale-down {
+  -o-object-fit: scale-down;
+  object-fit: scale-down;
+}
+
+.object-center {
+  -o-object-position: center;
+  object-position: center;
+}
+
+.p-0 {
+  padding: 0px;
+}
+
+.p-1 {
+  padding: 0.25rem;
+}
+
+.p-2 {
+  padding: 0.5rem;
+}
+
+.p-3 {
+  padding: 0.75rem;
+}
+
+.p-4 {
+  padding: 1rem;
+}
+
+.p-5 {
+  padding: 1.25rem;
+}
+
+.p-6 {
+  padding: 1.5rem;
+}
+
+.p-14 {
+  padding: 3.5rem;
+}
+
+.px-0 {
+  padding-left: 0px;
+  padding-right: 0px;
+}
+
+.px-1 {
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+}
+
+.px-2 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.px-3 {
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+}
+
+.px-4 {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.px-5 {
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+}
+
+.px-6 {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}
+
+.px-8 {
+  padding-left: 2rem;
+  padding-right: 2rem;
+}
+
+.px-10 {
+  padding-left: 2.5rem;
+  padding-right: 2.5rem;
+}
+
+.px-15 {
+  padding-left: 3.75rem;
+  padding-right: 3.75rem;
+}
+
+.px-16 {
+  padding-left: 4rem;
+  padding-right: 4rem;
+}
+
+.px-32 {
+  padding-left: 8rem;
+  padding-right: 8rem;
+}
+
+.py-0 {
+  padding-top: 0px;
+  padding-bottom: 0px;
+}
+
+.py-1 {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+
+.py-2 {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.py-3 {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+
+.py-4 {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.py-5 {
+  padding-top: 1.25rem;
+  padding-bottom: 1.25rem;
+}
+
+.py-6 {
+  padding-top: 1.5rem;
+  padding-bottom: 1.5rem;
+}
+
+.py-8 {
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+}
+
+.py-10 {
+  padding-top: 2.5rem;
+  padding-bottom: 2.5rem;
+}
+
+.py-12 {
+  padding-top: 3rem;
+  padding-bottom: 3rem;
+}
+
+.py-24 {
+  padding-top: 6rem;
+  padding-bottom: 6rem;
+}
+
+.py-48 {
+  padding-top: 12rem;
+  padding-bottom: 12rem;
+}
+
+.pt-0 {
+  padding-top: 0px;
+}
+
+.pt-1 {
+  padding-top: 0.25rem;
+}
+
+.pt-2 {
+  padding-top: 0.5rem;
+}
+
+.pt-3 {
+  padding-top: 0.75rem;
+}
+
+.pt-4 {
+  padding-top: 1rem;
+}
+
+.pt-5 {
+  padding-top: 1.25rem;
+}
+
+.pt-6 {
+  padding-top: 1.5rem;
+}
+
+.pt-8 {
+  padding-top: 2rem;
+}
+
+.pt-10 {
+  padding-top: 2.5rem;
+}
+
+.pt-12 {
+  padding-top: 3rem;
+}
+
+.pt-14 {
+  padding-top: 3.5rem;
+}
+
+.pt-16 {
+  padding-top: 4rem;
+}
+
+.pr-0 {
+  padding-right: 0px;
+}
+
+.pr-1 {
+  padding-right: 0.25rem;
+}
+
+.pr-2 {
+  padding-right: 0.5rem;
+}
+
+.pr-3 {
+  padding-right: 0.75rem;
+}
+
+.pr-4 {
+  padding-right: 1rem;
+}
+
+.pr-5 {
+  padding-right: 1.25rem;
+}
+
+.pr-6 {
+  padding-right: 1.5rem;
+}
+
+.pr-8 {
+  padding-right: 2rem;
+}
+
+.pr-14 {
+  padding-right: 3.5rem;
+}
+
+.pr-16 {
+  padding-right: 4rem;
+}
+
+.pb-0 {
+  padding-bottom: 0px;
+}
+
+.pb-1 {
+  padding-bottom: 0.25rem;
+}
+
+.pb-2 {
+  padding-bottom: 0.5rem;
+}
+
+.pb-3 {
+  padding-bottom: 0.75rem;
+}
+
+.pb-4 {
+  padding-bottom: 1rem;
+}
+
+.pb-5 {
+  padding-bottom: 1.25rem;
+}
+
+.pb-6 {
+  padding-bottom: 1.5rem;
+}
+
+.pb-8 {
+  padding-bottom: 2rem;
+}
+
+.pb-12 {
+  padding-bottom: 3rem;
+}
+
+.pb-16 {
+  padding-bottom: 4rem;
+}
+
+.pl-1 {
+  padding-left: 0.25rem;
+}
+
+.pl-2 {
+  padding-left: 0.5rem;
+}
+
+.pl-3 {
+  padding-left: 0.75rem;
+}
+
+.pl-4 {
+  padding-left: 1rem;
+}
+
+.pl-5 {
+  padding-left: 1.25rem;
+}
+
+.pl-6 {
+  padding-left: 1.5rem;
+}
+
+.pl-8 {
+  padding-left: 2rem;
+}
+
+.text-left {
+  text-align: left;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.align-middle {
+  vertical-align: middle;
+}
+
+.font-sans {
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+}
+
+.text-xs {
+  font-size: 0.75rem;
+  line-height: 1.125rem;
+}
+
+.text-sm {
+  font-size: 0.875rem;
+  line-height: 1.3125rem;
+}
+
+.text-base {
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+
+.text-lg {
+  font-size: 1.125rem;
+  line-height: 1.6875rem;
+}
+
+.text-xl {
+  font-size: 1.25rem;
+  line-height: 1.875rem;
+}
+
+.text-2xl {
+  font-size: 1.375rem;
+  line-height: 2.0625rem;
+}
+
+.text-5xl {
+  font-size: 1.75rem;
+  line-height: 2.625rem;
+}
+
+.font-normal {
+  font-weight: 400;
+}
+
+.font-bold {
+  font-weight: 700;
+}
+
+.lowercase {
+  text-transform: lowercase;
+}
+
+.italic {
+  font-style: italic;
+}
+
+.leading-6 {
+  line-height: 1.5rem;
+}
+
+.leading-tight {
+  line-height: 1.25;
+}
+
+.leading-normal {
+  line-height: 1.5;
+}
+
+.leading-relaxed {
+  line-height: 1.625;
+}
+
+.tracking-normal {
+  letter-spacing: 0em;
+}
+
+.text-neutrals-dark {
+  --tw-text-opacity: 1;
+  color: rgba(25, 12, 33, var(--tw-text-opacity));
+}
+
+.text-neutrals-medium {
+  --tw-text-opacity: 1;
+  color: rgba(108, 109, 124, var(--tw-text-opacity));
+}
+
+.text-neutrals-softWhite {
+  --tw-text-opacity: 1;
+  color: rgba(244, 241, 245, var(--tw-text-opacity));
+}
+
+.text-neutrals-white {
+  --tw-text-opacity: 1;
+  color: rgba(255, 255, 255, var(--tw-text-opacity));
+}
+
+.text-primary-blue {
+  --tw-text-opacity: 1;
+  color: rgba(40, 131, 251, var(--tw-text-opacity));
+}
+
+.text-primary-purple {
+  --tw-text-opacity: 1;
+  color: rgba(138, 53, 183, var(--tw-text-opacity));
+}
+
+.text-primary-valencia {
+  --tw-text-opacity: 1;
+  color: rgba(210, 67, 67, var(--tw-text-opacity));
+}
+
+.text-primary-vampire {
+  --tw-text-opacity: 1;
+  color: rgba(181, 19, 19, var(--tw-text-opacity));
+}
+
+.no-underline {
+  text-decoration: none;
+}
+
+.hover\:underline:hover {
+  text-decoration: underline;
+}
+
+.hover\:no-underline:hover {
+  text-decoration: none;
+}
+
+.opacity-20 {
+  opacity: 0.2;
+}
+
+.opacity-25 {
+  opacity: 0.25;
+}
+
+.opacity-40 {
+  opacity: 0.4;
+}
+
+.opacity-60 {
+  opacity: 0.6;
+}
+
+.opacity-100 {
+  opacity: 1;
+}
+
+.focus-within\:opacity-100:focus-within {
+  opacity: 1;
+}
+
+.hover\:opacity-100:hover {
+  opacity: 1;
+}
+
+.focus\:opacity-100:focus {
+  opacity: 1;
+}
+
+*,
+::before,
+::after {
+  --tw-shadow: 0 0 #0000;
+}
+
+.shadow {
+  --tw-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+  -webkit-box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
+    var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
+    var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-md {
+  --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  -webkit-box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
+    var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
+    var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-lg {
+  --tw-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1),
+    0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  -webkit-box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
+    var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
+    var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-xl {
+  --tw-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1),
+    0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  -webkit-box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
+    var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
+    var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-main-container {
+  --tw-shadow: 0px 0px 40px 0px rgba(25, 12, 33, 0.1);
+  -webkit-box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
+    var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
+    var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.focus-within\:shadow-inner-outline-blue:focus-within {
+  --tw-shadow: inset 0px 2px 0px 0px #2883fb, inset 0px -2px 0px 0px #2883fb;
+  -webkit-box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
+    var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
+    var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.outline-none {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.focus\:outline-none:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+*,
+::before,
+::after {
+  --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgba(59, 130, 246, 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+}
+
+.focus-within\:ring-2:focus-within {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0
+    var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0
+    calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  -webkit-box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
+    var(--tw-shadow, 0 0 #0000);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
+    var(--tw-shadow, 0 0 #0000);
+}
+
+.focus\:ring-1:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0
+    var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0
+    calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  -webkit-box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
+    var(--tw-shadow, 0 0 #0000);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
+    var(--tw-shadow, 0 0 #0000);
+}
+
+.focus\:ring-2:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0
+    var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0
+    calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  -webkit-box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
+    var(--tw-shadow, 0 0 #0000);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
+    var(--tw-shadow, 0 0 #0000);
+}
+
+.focus\:ring:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0
+    var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0
+    calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  -webkit-box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
+    var(--tw-shadow, 0 0 #0000);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
+    var(--tw-shadow, 0 0 #0000);
+}
+
+.ring-primary-blue {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(40, 131, 251, var(--tw-ring-opacity));
+}
+
+.ring-primary-boatBlue {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(43, 82, 131, var(--tw-ring-opacity));
+}
+
+.ring-primary-boatBlue-dark {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(30, 58, 93, var(--tw-ring-opacity));
+}
+
+.ring-primary-boatBlue-light {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(56, 106, 169, var(--tw-ring-opacity));
+}
+
+.ring-primary-cobalt {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(49, 50, 131, var(--tw-ring-opacity));
+}
+
+.ring-primary-cobalt-dark {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(35, 36, 94, var(--tw-ring-opacity));
+}
+
+.ring-primary-cobalt-light {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(63, 64, 168, var(--tw-ring-opacity));
+}
+
+.ring-primary-coral {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(237, 103, 101, var(--tw-ring-opacity));
+}
+
+.ring-primary-green {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(39, 123, 62, var(--tw-ring-opacity));
+}
+
+.ring-primary-green-dark {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(27, 84, 42, var(--tw-ring-opacity));
+}
+
+.ring-primary-green-light {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(51, 162, 82, var(--tw-ring-opacity));
+}
+
+.ring-primary-pink {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(231, 69, 119, var(--tw-ring-opacity));
+}
+
+.ring-primary-purple {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(138, 53, 183, var(--tw-ring-opacity));
+}
+
+.ring-primary-purple-hashita {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(138, 93, 138, var(--tw-ring-opacity));
+}
+
+.ring-primary-red {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(174, 0, 2, var(--tw-ring-opacity));
+}
+
+.ring-primary-red-dark {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(123, 0, 1, var(--tw-ring-opacity));
+}
+
+.ring-primary-red-light {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(225, 0, 3, var(--tw-ring-opacity));
+}
+
+.ring-primary-valencia {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(210, 67, 67, var(--tw-ring-opacity));
+}
+
+.ring-primary-vampire {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(181, 19, 19, var(--tw-ring-opacity));
+}
+
+.focus-within\:ring-neutrals-victorianPewter:focus-within {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(129, 131, 138, var(--tw-ring-opacity));
+}
+
+.focus-within\:ring-primary-blue:focus-within {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(40, 131, 251, var(--tw-ring-opacity));
+}
+
+.focus-within\:ring-primary-boatBlue:focus-within {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(43, 82, 131, var(--tw-ring-opacity));
+}
+
+.focus-within\:ring-primary-boatBlue-dark:focus-within {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(30, 58, 93, var(--tw-ring-opacity));
+}
+
+.focus-within\:ring-primary-boatBlue-light:focus-within {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(56, 106, 169, var(--tw-ring-opacity));
+}
+
+.focus-within\:ring-primary-cobalt:focus-within {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(49, 50, 131, var(--tw-ring-opacity));
+}
+
+.focus-within\:ring-primary-cobalt-dark:focus-within {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(35, 36, 94, var(--tw-ring-opacity));
+}
+
+.focus-within\:ring-primary-cobalt-light:focus-within {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(63, 64, 168, var(--tw-ring-opacity));
+}
+
+.focus-within\:ring-primary-coral:focus-within {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(237, 103, 101, var(--tw-ring-opacity));
+}
+
+.focus-within\:ring-primary-green:focus-within {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(39, 123, 62, var(--tw-ring-opacity));
+}
+
+.focus-within\:ring-primary-green-dark:focus-within {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(27, 84, 42, var(--tw-ring-opacity));
+}
+
+.focus-within\:ring-primary-green-light:focus-within {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(51, 162, 82, var(--tw-ring-opacity));
+}
+
+.focus-within\:ring-primary-pink:focus-within {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(231, 69, 119, var(--tw-ring-opacity));
+}
+
+.focus-within\:ring-primary-purple:focus-within {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(138, 53, 183, var(--tw-ring-opacity));
+}
+
+.focus-within\:ring-primary-purple-hashita:focus-within {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(138, 93, 138, var(--tw-ring-opacity));
+}
+
+.focus-within\:ring-primary-red:focus-within {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(174, 0, 2, var(--tw-ring-opacity));
+}
+
+.focus-within\:ring-primary-red-dark:focus-within {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(123, 0, 1, var(--tw-ring-opacity));
+}
+
+.focus-within\:ring-primary-red-light:focus-within {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(225, 0, 3, var(--tw-ring-opacity));
+}
+
+.focus-within\:ring-primary-valencia:focus-within {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(210, 67, 67, var(--tw-ring-opacity));
+}
+
+.focus-within\:ring-primary-vampire:focus-within {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(181, 19, 19, var(--tw-ring-opacity));
+}
+
+.focus\:ring-primary-blue:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(40, 131, 251, var(--tw-ring-opacity));
+}
+
+.focus\:ring-primary-boatBlue:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(43, 82, 131, var(--tw-ring-opacity));
+}
+
+.focus\:ring-primary-boatBlue-dark:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(30, 58, 93, var(--tw-ring-opacity));
+}
+
+.focus\:ring-primary-boatBlue-light:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(56, 106, 169, var(--tw-ring-opacity));
+}
+
+.focus\:ring-primary-cobalt:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(49, 50, 131, var(--tw-ring-opacity));
+}
+
+.focus\:ring-primary-cobalt-dark:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(35, 36, 94, var(--tw-ring-opacity));
+}
+
+.focus\:ring-primary-cobalt-light:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(63, 64, 168, var(--tw-ring-opacity));
+}
+
+.focus\:ring-primary-coral:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(237, 103, 101, var(--tw-ring-opacity));
+}
+
+.focus\:ring-primary-green:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(39, 123, 62, var(--tw-ring-opacity));
+}
+
+.focus\:ring-primary-green-dark:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(27, 84, 42, var(--tw-ring-opacity));
+}
+
+.focus\:ring-primary-green-light:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(51, 162, 82, var(--tw-ring-opacity));
+}
+
+.focus\:ring-primary-pink:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(231, 69, 119, var(--tw-ring-opacity));
+}
+
+.focus\:ring-primary-purple:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(138, 53, 183, var(--tw-ring-opacity));
+}
+
+.focus\:ring-primary-purple-hashita:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(138, 93, 138, var(--tw-ring-opacity));
+}
+
+.focus\:ring-primary-red:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(174, 0, 2, var(--tw-ring-opacity));
+}
+
+.focus\:ring-primary-red-dark:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(123, 0, 1, var(--tw-ring-opacity));
+}
+
+.focus\:ring-primary-red-light:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(225, 0, 3, var(--tw-ring-opacity));
+}
+
+.focus\:ring-primary-valencia:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(210, 67, 67, var(--tw-ring-opacity));
+}
+
+.focus\:ring-primary-vampire:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(181, 19, 19, var(--tw-ring-opacity));
+}
+
+.focus\:ring-opacity-70:focus {
+  --tw-ring-opacity: 0.7;
+}
+
+.focus-within\:ring-offset-2:focus-within {
+  --tw-ring-offset-width: 2px;
+}
+
+.filter {
+  --tw-blur: var(--tw-empty, /*!*/ /*!*/);
+  --tw-brightness: var(--tw-empty, /*!*/ /*!*/);
+  --tw-contrast: var(--tw-empty, /*!*/ /*!*/);
+  --tw-grayscale: var(--tw-empty, /*!*/ /*!*/);
+  --tw-hue-rotate: var(--tw-empty, /*!*/ /*!*/);
+  --tw-invert: var(--tw-empty, /*!*/ /*!*/);
+  --tw-saturate: var(--tw-empty, /*!*/ /*!*/);
+  --tw-sepia: var(--tw-empty, /*!*/ /*!*/);
+  --tw-drop-shadow: var(--tw-empty, /*!*/ /*!*/);
+  -webkit-filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast)
+    var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate)
+    var(--tw-sepia) var(--tw-drop-shadow);
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast)
+    var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate)
+    var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+.blur {
+  --tw-blur: blur(8px);
+}
+
+.transition {
+  -webkit-transition-property: background-color, border-color, color, fill,
+    stroke, opacity, -webkit-box-shadow, -webkit-transform, -webkit-filter,
+    -webkit-backdrop-filter;
+  transition-property: background-color, border-color, color, fill, stroke,
+    opacity, -webkit-box-shadow, -webkit-transform, -webkit-filter,
+    -webkit-backdrop-filter;
+  transition-property: background-color, border-color, color, fill, stroke,
+    opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-property: background-color, border-color, color, fill, stroke,
+    opacity, box-shadow, transform, filter, backdrop-filter, -webkit-box-shadow,
+    -webkit-transform, -webkit-filter, -webkit-backdrop-filter;
+  -webkit-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  -webkit-transition-duration: 150ms;
+  transition-duration: 150ms;
+}
+
+.ease-in-out {
+  -webkit-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@media (min-width: 640px) {
+  .sm\:h-8 {
+    height: 2rem;
+  }
+
+  .sm\:w-10 {
+    width: 2.5rem;
+  }
+
+  .sm\:w-screen {
+    width: 100vw;
+  }
+
+  .sm\:bg-gradient-to-t {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  }
+
+  .sm\:bg-gradient-to-tr {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+  }
+
+  .sm\:bg-gradient-to-r {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  }
+
+  .sm\:bg-gradient-to-br {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(
+      to bottom right,
+      var(--tw-gradient-stops)
+    );
+  }
+
+  .sm\:bg-gradient-to-b {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+  }
+
+  .sm\:bg-gradient-to-bl {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+  }
+
+  .sm\:bg-gradient-to-l {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to left, var(--tw-gradient-stops));
+  }
+
+  .sm\:bg-gradient-to-tl {
+    background-image: -webkit-gradient(
+      linear,
+      right bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+  }
+
+  .sm\:bg-gradient-boatBlue {
+    background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+  }
+
+  .sm\:bg-gradient-cobalt {
+    background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+  }
+
+  .sm\:bg-gradient-dark {
+    background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+  }
+
+  .sm\:bg-gradient-harold {
+    background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+  }
+
+  .sm\:bg-gradient-full {
+    background-image: linear-gradient(
+      -225deg,
+      #ec857c 0%,
+      #cc3566 26%,
+      #df7f75 47%,
+      #90399e 66%,
+      #5d5cbd 83%,
+      #2f97d9 100%
+    );
+  }
+
+  .sm\:bg-gradient-green {
+    background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+  }
+
+  .sm\:bg-gradient-pink {
+    background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+  }
+
+  .sm\:bg-gradient-purple {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#8631a0),
+      to(#360b4c)
+    );
+    background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  }
+
+  .sm\:bg-gradient-red {
+    background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+  }
+
+  .sm\:focus-within\:bg-gradient-to-t:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  }
+
+  .sm\:focus-within\:bg-gradient-to-tr:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+  }
+
+  .sm\:focus-within\:bg-gradient-to-r:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  }
+
+  .sm\:focus-within\:bg-gradient-to-br:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(
+      to bottom right,
+      var(--tw-gradient-stops)
+    );
+  }
+
+  .sm\:focus-within\:bg-gradient-to-b:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+  }
+
+  .sm\:focus-within\:bg-gradient-to-bl:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+  }
+
+  .sm\:focus-within\:bg-gradient-to-l:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to left, var(--tw-gradient-stops));
+  }
+
+  .sm\:focus-within\:bg-gradient-to-tl:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      right bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+  }
+
+  .sm\:focus-within\:bg-gradient-boatBlue:focus-within {
+    background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+  }
+
+  .sm\:focus-within\:bg-gradient-cobalt:focus-within {
+    background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+  }
+
+  .sm\:focus-within\:bg-gradient-dark:focus-within {
+    background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+  }
+
+  .sm\:focus-within\:bg-gradient-harold:focus-within {
+    background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+  }
+
+  .sm\:focus-within\:bg-gradient-full:focus-within {
+    background-image: linear-gradient(
+      -225deg,
+      #ec857c 0%,
+      #cc3566 26%,
+      #df7f75 47%,
+      #90399e 66%,
+      #5d5cbd 83%,
+      #2f97d9 100%
+    );
+  }
+
+  .sm\:focus-within\:bg-gradient-green:focus-within {
+    background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+  }
+
+  .sm\:focus-within\:bg-gradient-pink:focus-within {
+    background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+  }
+
+  .sm\:focus-within\:bg-gradient-purple:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#8631a0),
+      to(#360b4c)
+    );
+    background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  }
+
+  .sm\:focus-within\:bg-gradient-red:focus-within {
+    background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+  }
+
+  .sm\:hover\:bg-gradient-to-t:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  }
+
+  .sm\:hover\:bg-gradient-to-tr:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+  }
+
+  .sm\:hover\:bg-gradient-to-r:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  }
+
+  .sm\:hover\:bg-gradient-to-br:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(
+      to bottom right,
+      var(--tw-gradient-stops)
+    );
+  }
+
+  .sm\:hover\:bg-gradient-to-b:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+  }
+
+  .sm\:hover\:bg-gradient-to-bl:hover {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+  }
+
+  .sm\:hover\:bg-gradient-to-l:hover {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to left, var(--tw-gradient-stops));
+  }
+
+  .sm\:hover\:bg-gradient-to-tl:hover {
+    background-image: -webkit-gradient(
+      linear,
+      right bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+  }
+
+  .sm\:hover\:bg-gradient-boatBlue:hover {
+    background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+  }
+
+  .sm\:hover\:bg-gradient-cobalt:hover {
+    background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+  }
+
+  .sm\:hover\:bg-gradient-dark:hover {
+    background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+  }
+
+  .sm\:hover\:bg-gradient-harold:hover {
+    background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+  }
+
+  .sm\:hover\:bg-gradient-full:hover {
+    background-image: linear-gradient(
+      -225deg,
+      #ec857c 0%,
+      #cc3566 26%,
+      #df7f75 47%,
+      #90399e 66%,
+      #5d5cbd 83%,
+      #2f97d9 100%
+    );
+  }
+
+  .sm\:hover\:bg-gradient-green:hover {
+    background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+  }
+
+  .sm\:hover\:bg-gradient-pink:hover {
+    background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+  }
+
+  .sm\:hover\:bg-gradient-purple:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#8631a0),
+      to(#360b4c)
+    );
+    background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  }
+
+  .sm\:hover\:bg-gradient-red:hover {
+    background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+  }
+
+  .sm\:disabled\:bg-gradient-to-t:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  }
+
+  .sm\:disabled\:bg-gradient-to-tr:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+  }
+
+  .sm\:disabled\:bg-gradient-to-r:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  }
+
+  .sm\:disabled\:bg-gradient-to-br:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(
+      to bottom right,
+      var(--tw-gradient-stops)
+    );
+  }
+
+  .sm\:disabled\:bg-gradient-to-b:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+  }
+
+  .sm\:disabled\:bg-gradient-to-bl:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+  }
+
+  .sm\:disabled\:bg-gradient-to-l:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to left, var(--tw-gradient-stops));
+  }
+
+  .sm\:disabled\:bg-gradient-to-tl:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      right bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+  }
+
+  .sm\:disabled\:bg-gradient-boatBlue:disabled {
+    background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+  }
+
+  .sm\:disabled\:bg-gradient-cobalt:disabled {
+    background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+  }
+
+  .sm\:disabled\:bg-gradient-dark:disabled {
+    background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+  }
+
+  .sm\:disabled\:bg-gradient-harold:disabled {
+    background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+  }
+
+  .sm\:disabled\:bg-gradient-full:disabled {
+    background-image: linear-gradient(
+      -225deg,
+      #ec857c 0%,
+      #cc3566 26%,
+      #df7f75 47%,
+      #90399e 66%,
+      #5d5cbd 83%,
+      #2f97d9 100%
+    );
+  }
+
+  .sm\:disabled\:bg-gradient-green:disabled {
+    background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+  }
+
+  .sm\:disabled\:bg-gradient-pink:disabled {
+    background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+  }
+
+  .sm\:disabled\:bg-gradient-purple:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#8631a0),
+      to(#360b4c)
+    );
+    background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  }
+
+  .sm\:disabled\:bg-gradient-red:disabled {
+    background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+  }
+
+  .sm\:px-11 {
+    padding-left: 2.75rem;
+    padding-right: 2.75rem;
+  }
+
+  .sm\:text-xs {
+    font-size: 0.75rem;
+    line-height: 1.125rem;
+  }
+
+  .sm\:text-sm {
+    font-size: 0.875rem;
+    line-height: 1.3125rem;
+  }
+
+  .sm\:ring-primary-blue {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(40, 131, 251, var(--tw-ring-opacity));
+  }
+
+  .sm\:ring-primary-boatBlue {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(43, 82, 131, var(--tw-ring-opacity));
+  }
+
+  .sm\:ring-primary-boatBlue-dark {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(30, 58, 93, var(--tw-ring-opacity));
+  }
+
+  .sm\:ring-primary-boatBlue-light {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(56, 106, 169, var(--tw-ring-opacity));
+  }
+
+  .sm\:ring-primary-cobalt {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(49, 50, 131, var(--tw-ring-opacity));
+  }
+
+  .sm\:ring-primary-cobalt-dark {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(35, 36, 94, var(--tw-ring-opacity));
+  }
+
+  .sm\:ring-primary-cobalt-light {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(63, 64, 168, var(--tw-ring-opacity));
+  }
+
+  .sm\:ring-primary-coral {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(237, 103, 101, var(--tw-ring-opacity));
+  }
+
+  .sm\:ring-primary-green {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(39, 123, 62, var(--tw-ring-opacity));
+  }
+
+  .sm\:ring-primary-green-dark {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(27, 84, 42, var(--tw-ring-opacity));
+  }
+
+  .sm\:ring-primary-green-light {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(51, 162, 82, var(--tw-ring-opacity));
+  }
+
+  .sm\:ring-primary-pink {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(231, 69, 119, var(--tw-ring-opacity));
+  }
+
+  .sm\:ring-primary-purple {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 53, 183, var(--tw-ring-opacity));
+  }
+
+  .sm\:ring-primary-purple-hashita {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 93, 138, var(--tw-ring-opacity));
+  }
+
+  .sm\:ring-primary-red {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(174, 0, 2, var(--tw-ring-opacity));
+  }
+
+  .sm\:ring-primary-red-dark {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(123, 0, 1, var(--tw-ring-opacity));
+  }
+
+  .sm\:ring-primary-red-light {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(225, 0, 3, var(--tw-ring-opacity));
+  }
+
+  .sm\:ring-primary-valencia {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(210, 67, 67, var(--tw-ring-opacity));
+  }
+
+  .sm\:ring-primary-vampire {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(181, 19, 19, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus-within\:ring-primary-blue:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(40, 131, 251, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus-within\:ring-primary-boatBlue:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(43, 82, 131, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus-within\:ring-primary-boatBlue-dark:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(30, 58, 93, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus-within\:ring-primary-boatBlue-light:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(56, 106, 169, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus-within\:ring-primary-cobalt:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(49, 50, 131, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus-within\:ring-primary-cobalt-dark:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(35, 36, 94, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus-within\:ring-primary-cobalt-light:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(63, 64, 168, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus-within\:ring-primary-coral:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(237, 103, 101, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus-within\:ring-primary-green:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(39, 123, 62, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus-within\:ring-primary-green-dark:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(27, 84, 42, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus-within\:ring-primary-green-light:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(51, 162, 82, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus-within\:ring-primary-pink:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(231, 69, 119, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus-within\:ring-primary-purple:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 53, 183, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus-within\:ring-primary-purple-hashita:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 93, 138, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus-within\:ring-primary-red:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(174, 0, 2, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus-within\:ring-primary-red-dark:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(123, 0, 1, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus-within\:ring-primary-red-light:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(225, 0, 3, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus-within\:ring-primary-valencia:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(210, 67, 67, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus-within\:ring-primary-vampire:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(181, 19, 19, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus\:ring-primary-blue:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(40, 131, 251, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus\:ring-primary-boatBlue:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(43, 82, 131, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus\:ring-primary-boatBlue-dark:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(30, 58, 93, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus\:ring-primary-boatBlue-light:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(56, 106, 169, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus\:ring-primary-cobalt:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(49, 50, 131, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus\:ring-primary-cobalt-dark:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(35, 36, 94, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus\:ring-primary-cobalt-light:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(63, 64, 168, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus\:ring-primary-coral:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(237, 103, 101, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus\:ring-primary-green:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(39, 123, 62, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus\:ring-primary-green-dark:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(27, 84, 42, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus\:ring-primary-green-light:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(51, 162, 82, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus\:ring-primary-pink:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(231, 69, 119, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus\:ring-primary-purple:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 53, 183, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus\:ring-primary-purple-hashita:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 93, 138, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus\:ring-primary-red:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(174, 0, 2, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus\:ring-primary-red-dark:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(123, 0, 1, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus\:ring-primary-red-light:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(225, 0, 3, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus\:ring-primary-valencia:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(210, 67, 67, var(--tw-ring-opacity));
+  }
+
+  .sm\:focus\:ring-primary-vampire:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(181, 19, 19, var(--tw-ring-opacity));
+  }
+}
+
+@media (min-width: 768px) {
+  .md\:z-10 {
+    z-index: 10;
+  }
+
+  .md\:order-last {
+    -webkit-box-ordinal-group: 10000;
+    -ms-flex-order: 9999;
+    order: 9999;
+  }
+
+  .md\:mx-0 {
+    margin-left: 0px;
+    margin-right: 0px;
+  }
+
+  .md\:mt-2 {
+    margin-top: 0.5rem;
+  }
+
+  .md\:mt-6 {
+    margin-top: 1.5rem;
+  }
+
+  .md\:mb-8 {
+    margin-bottom: 2rem;
+  }
+
+  .md\:block {
+    display: block;
+  }
+
+  .md\:flex {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+  }
+
+  .md\:hidden {
+    display: none;
+  }
+
+  .md\:h-24 {
+    height: 6rem;
+  }
+
+  .md\:h-40 {
+    height: 10rem;
+  }
+
+  .md\:h-auto {
+    height: auto;
+  }
+
+  .md\:min-h-screen {
+    min-height: 100vh;
+  }
+
+  .md\:w-80 {
+    width: 20rem;
+  }
+
+  .md\:w-auto {
+    width: auto;
+  }
+
+  .md\:w-1\/3 {
+    width: 33.333333%;
+  }
+
+  .md\:w-2\/3 {
+    width: 66.666667%;
+  }
+
+  .md\:w-2\/5 {
+    width: 40%;
+  }
+
+  .md\:max-w-4xl {
+    max-width: 56rem;
+  }
+
+  .md\:flex-grow-0 {
+    -webkit-box-flex: 0;
+    -ms-flex-positive: 0;
+    flex-grow: 0;
+  }
+
+  .md\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .md\:flex-row {
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+
+  .md\:flex-col {
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+
+  .md\:flex-wrap {
+    -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
+  }
+
+  .md\:justify-between {
+    -webkit-box-pack: justify;
+    -ms-flex-pack: justify;
+    justify-content: space-between;
+  }
+
+  .md\:rounded {
+    border-radius: 0.25rem;
+  }
+
+  .md\:rounded-lg {
+    border-radius: 0.5rem;
+  }
+
+  .md\:border {
+    border-width: 1px;
+  }
+
+  .md\:border-t-0 {
+    border-top-width: 0px;
+  }
+
+  .md\:bg-gradient-to-t {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  }
+
+  .md\:bg-gradient-to-tr {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+  }
+
+  .md\:bg-gradient-to-r {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  }
+
+  .md\:bg-gradient-to-br {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(
+      to bottom right,
+      var(--tw-gradient-stops)
+    );
+  }
+
+  .md\:bg-gradient-to-b {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+  }
+
+  .md\:bg-gradient-to-bl {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+  }
+
+  .md\:bg-gradient-to-l {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to left, var(--tw-gradient-stops));
+  }
+
+  .md\:bg-gradient-to-tl {
+    background-image: -webkit-gradient(
+      linear,
+      right bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+  }
+
+  .md\:bg-gradient-boatBlue {
+    background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+  }
+
+  .md\:bg-gradient-cobalt {
+    background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+  }
+
+  .md\:bg-gradient-dark {
+    background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+  }
+
+  .md\:bg-gradient-harold {
+    background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+  }
+
+  .md\:bg-gradient-full {
+    background-image: linear-gradient(
+      -225deg,
+      #ec857c 0%,
+      #cc3566 26%,
+      #df7f75 47%,
+      #90399e 66%,
+      #5d5cbd 83%,
+      #2f97d9 100%
+    );
+  }
+
+  .md\:bg-gradient-green {
+    background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+  }
+
+  .md\:bg-gradient-pink {
+    background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+  }
+
+  .md\:bg-gradient-purple {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#8631a0),
+      to(#360b4c)
+    );
+    background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  }
+
+  .md\:bg-gradient-red {
+    background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+  }
+
+  .md\:bg-onboarding {
+    background-image: url("~@/assets/img/onboarding-bg-lg.svg");
+  }
+
+  .md\:focus-within\:bg-gradient-to-t:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  }
+
+  .md\:focus-within\:bg-gradient-to-tr:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+  }
+
+  .md\:focus-within\:bg-gradient-to-r:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  }
+
+  .md\:focus-within\:bg-gradient-to-br:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(
+      to bottom right,
+      var(--tw-gradient-stops)
+    );
+  }
+
+  .md\:focus-within\:bg-gradient-to-b:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+  }
+
+  .md\:focus-within\:bg-gradient-to-bl:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+  }
+
+  .md\:focus-within\:bg-gradient-to-l:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to left, var(--tw-gradient-stops));
+  }
+
+  .md\:focus-within\:bg-gradient-to-tl:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      right bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+  }
+
+  .md\:focus-within\:bg-gradient-boatBlue:focus-within {
+    background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+  }
+
+  .md\:focus-within\:bg-gradient-cobalt:focus-within {
+    background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+  }
+
+  .md\:focus-within\:bg-gradient-dark:focus-within {
+    background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+  }
+
+  .md\:focus-within\:bg-gradient-harold:focus-within {
+    background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+  }
+
+  .md\:focus-within\:bg-gradient-full:focus-within {
+    background-image: linear-gradient(
+      -225deg,
+      #ec857c 0%,
+      #cc3566 26%,
+      #df7f75 47%,
+      #90399e 66%,
+      #5d5cbd 83%,
+      #2f97d9 100%
+    );
+  }
+
+  .md\:focus-within\:bg-gradient-green:focus-within {
+    background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+  }
+
+  .md\:focus-within\:bg-gradient-pink:focus-within {
+    background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+  }
+
+  .md\:focus-within\:bg-gradient-purple:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#8631a0),
+      to(#360b4c)
+    );
+    background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  }
+
+  .md\:focus-within\:bg-gradient-red:focus-within {
+    background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+  }
+
+  .md\:hover\:bg-gradient-to-t:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  }
+
+  .md\:hover\:bg-gradient-to-tr:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+  }
+
+  .md\:hover\:bg-gradient-to-r:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  }
+
+  .md\:hover\:bg-gradient-to-br:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(
+      to bottom right,
+      var(--tw-gradient-stops)
+    );
+  }
+
+  .md\:hover\:bg-gradient-to-b:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+  }
+
+  .md\:hover\:bg-gradient-to-bl:hover {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+  }
+
+  .md\:hover\:bg-gradient-to-l:hover {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to left, var(--tw-gradient-stops));
+  }
+
+  .md\:hover\:bg-gradient-to-tl:hover {
+    background-image: -webkit-gradient(
+      linear,
+      right bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+  }
+
+  .md\:hover\:bg-gradient-boatBlue:hover {
+    background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+  }
+
+  .md\:hover\:bg-gradient-cobalt:hover {
+    background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+  }
+
+  .md\:hover\:bg-gradient-dark:hover {
+    background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+  }
+
+  .md\:hover\:bg-gradient-harold:hover {
+    background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+  }
+
+  .md\:hover\:bg-gradient-full:hover {
+    background-image: linear-gradient(
+      -225deg,
+      #ec857c 0%,
+      #cc3566 26%,
+      #df7f75 47%,
+      #90399e 66%,
+      #5d5cbd 83%,
+      #2f97d9 100%
+    );
+  }
+
+  .md\:hover\:bg-gradient-green:hover {
+    background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+  }
+
+  .md\:hover\:bg-gradient-pink:hover {
+    background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+  }
+
+  .md\:hover\:bg-gradient-purple:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#8631a0),
+      to(#360b4c)
+    );
+    background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  }
+
+  .md\:hover\:bg-gradient-red:hover {
+    background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+  }
+
+  .md\:disabled\:bg-gradient-to-t:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  }
+
+  .md\:disabled\:bg-gradient-to-tr:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+  }
+
+  .md\:disabled\:bg-gradient-to-r:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  }
+
+  .md\:disabled\:bg-gradient-to-br:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(
+      to bottom right,
+      var(--tw-gradient-stops)
+    );
+  }
+
+  .md\:disabled\:bg-gradient-to-b:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+  }
+
+  .md\:disabled\:bg-gradient-to-bl:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+  }
+
+  .md\:disabled\:bg-gradient-to-l:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to left, var(--tw-gradient-stops));
+  }
+
+  .md\:disabled\:bg-gradient-to-tl:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      right bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+  }
+
+  .md\:disabled\:bg-gradient-boatBlue:disabled {
+    background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+  }
+
+  .md\:disabled\:bg-gradient-cobalt:disabled {
+    background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+  }
+
+  .md\:disabled\:bg-gradient-dark:disabled {
+    background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+  }
+
+  .md\:disabled\:bg-gradient-harold:disabled {
+    background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+  }
+
+  .md\:disabled\:bg-gradient-full:disabled {
+    background-image: linear-gradient(
+      -225deg,
+      #ec857c 0%,
+      #cc3566 26%,
+      #df7f75 47%,
+      #90399e 66%,
+      #5d5cbd 83%,
+      #2f97d9 100%
+    );
+  }
+
+  .md\:disabled\:bg-gradient-green:disabled {
+    background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+  }
+
+  .md\:disabled\:bg-gradient-pink:disabled {
+    background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+  }
+
+  .md\:disabled\:bg-gradient-purple:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#8631a0),
+      to(#360b4c)
+    );
+    background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  }
+
+  .md\:disabled\:bg-gradient-red:disabled {
+    background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+  }
+
+  .md\:px-0 {
+    padding-left: 0px;
+    padding-right: 0px;
+  }
+
+  .md\:px-8 {
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
+
+  .md\:px-20 {
+    padding-left: 5rem;
+    padding-right: 5rem;
+  }
+
+  .md\:py-12 {
+    padding-top: 3rem;
+    padding-bottom: 3rem;
+  }
+
+  .md\:pt-5 {
+    padding-top: 1.25rem;
+  }
+
+  .md\:pt-12 {
+    padding-top: 3rem;
+  }
+
+  .md\:pt-16 {
+    padding-top: 4rem;
+  }
+
+  .md\:pr-0 {
+    padding-right: 0px;
+  }
+
+  .md\:pb-0 {
+    padding-bottom: 0px;
+  }
+
+  .md\:pb-12 {
+    padding-bottom: 3rem;
+  }
+
+  .md\:pl-16 {
+    padding-left: 4rem;
+  }
+
+  .md\:text-left {
+    text-align: left;
+  }
+
+  .md\:text-base {
+    font-size: 1rem;
+    line-height: 1.5rem;
+  }
+
+  .md\:text-3xl {
+    font-size: 1.5rem;
+    line-height: 2.25rem;
+  }
+
+  .md\:text-4xl {
+    font-size: 1.625rem;
+    line-height: 2.4375rem;
+  }
+
+  .md\:ring-primary-blue {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(40, 131, 251, var(--tw-ring-opacity));
+  }
+
+  .md\:ring-primary-boatBlue {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(43, 82, 131, var(--tw-ring-opacity));
+  }
+
+  .md\:ring-primary-boatBlue-dark {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(30, 58, 93, var(--tw-ring-opacity));
+  }
+
+  .md\:ring-primary-boatBlue-light {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(56, 106, 169, var(--tw-ring-opacity));
+  }
+
+  .md\:ring-primary-cobalt {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(49, 50, 131, var(--tw-ring-opacity));
+  }
+
+  .md\:ring-primary-cobalt-dark {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(35, 36, 94, var(--tw-ring-opacity));
+  }
+
+  .md\:ring-primary-cobalt-light {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(63, 64, 168, var(--tw-ring-opacity));
+  }
+
+  .md\:ring-primary-coral {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(237, 103, 101, var(--tw-ring-opacity));
+  }
+
+  .md\:ring-primary-green {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(39, 123, 62, var(--tw-ring-opacity));
+  }
+
+  .md\:ring-primary-green-dark {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(27, 84, 42, var(--tw-ring-opacity));
+  }
+
+  .md\:ring-primary-green-light {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(51, 162, 82, var(--tw-ring-opacity));
+  }
+
+  .md\:ring-primary-pink {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(231, 69, 119, var(--tw-ring-opacity));
+  }
+
+  .md\:ring-primary-purple {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 53, 183, var(--tw-ring-opacity));
+  }
+
+  .md\:ring-primary-purple-hashita {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 93, 138, var(--tw-ring-opacity));
+  }
+
+  .md\:ring-primary-red {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(174, 0, 2, var(--tw-ring-opacity));
+  }
+
+  .md\:ring-primary-red-dark {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(123, 0, 1, var(--tw-ring-opacity));
+  }
+
+  .md\:ring-primary-red-light {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(225, 0, 3, var(--tw-ring-opacity));
+  }
+
+  .md\:ring-primary-valencia {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(210, 67, 67, var(--tw-ring-opacity));
+  }
+
+  .md\:ring-primary-vampire {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(181, 19, 19, var(--tw-ring-opacity));
+  }
+
+  .md\:focus-within\:ring-primary-blue:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(40, 131, 251, var(--tw-ring-opacity));
+  }
+
+  .md\:focus-within\:ring-primary-boatBlue:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(43, 82, 131, var(--tw-ring-opacity));
+  }
+
+  .md\:focus-within\:ring-primary-boatBlue-dark:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(30, 58, 93, var(--tw-ring-opacity));
+  }
+
+  .md\:focus-within\:ring-primary-boatBlue-light:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(56, 106, 169, var(--tw-ring-opacity));
+  }
+
+  .md\:focus-within\:ring-primary-cobalt:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(49, 50, 131, var(--tw-ring-opacity));
+  }
+
+  .md\:focus-within\:ring-primary-cobalt-dark:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(35, 36, 94, var(--tw-ring-opacity));
+  }
+
+  .md\:focus-within\:ring-primary-cobalt-light:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(63, 64, 168, var(--tw-ring-opacity));
+  }
+
+  .md\:focus-within\:ring-primary-coral:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(237, 103, 101, var(--tw-ring-opacity));
+  }
+
+  .md\:focus-within\:ring-primary-green:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(39, 123, 62, var(--tw-ring-opacity));
+  }
+
+  .md\:focus-within\:ring-primary-green-dark:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(27, 84, 42, var(--tw-ring-opacity));
+  }
+
+  .md\:focus-within\:ring-primary-green-light:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(51, 162, 82, var(--tw-ring-opacity));
+  }
+
+  .md\:focus-within\:ring-primary-pink:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(231, 69, 119, var(--tw-ring-opacity));
+  }
+
+  .md\:focus-within\:ring-primary-purple:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 53, 183, var(--tw-ring-opacity));
+  }
+
+  .md\:focus-within\:ring-primary-purple-hashita:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 93, 138, var(--tw-ring-opacity));
+  }
+
+  .md\:focus-within\:ring-primary-red:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(174, 0, 2, var(--tw-ring-opacity));
+  }
+
+  .md\:focus-within\:ring-primary-red-dark:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(123, 0, 1, var(--tw-ring-opacity));
+  }
+
+  .md\:focus-within\:ring-primary-red-light:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(225, 0, 3, var(--tw-ring-opacity));
+  }
+
+  .md\:focus-within\:ring-primary-valencia:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(210, 67, 67, var(--tw-ring-opacity));
+  }
+
+  .md\:focus-within\:ring-primary-vampire:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(181, 19, 19, var(--tw-ring-opacity));
+  }
+
+  .md\:focus\:ring-primary-blue:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(40, 131, 251, var(--tw-ring-opacity));
+  }
+
+  .md\:focus\:ring-primary-boatBlue:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(43, 82, 131, var(--tw-ring-opacity));
+  }
+
+  .md\:focus\:ring-primary-boatBlue-dark:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(30, 58, 93, var(--tw-ring-opacity));
+  }
+
+  .md\:focus\:ring-primary-boatBlue-light:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(56, 106, 169, var(--tw-ring-opacity));
+  }
+
+  .md\:focus\:ring-primary-cobalt:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(49, 50, 131, var(--tw-ring-opacity));
+  }
+
+  .md\:focus\:ring-primary-cobalt-dark:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(35, 36, 94, var(--tw-ring-opacity));
+  }
+
+  .md\:focus\:ring-primary-cobalt-light:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(63, 64, 168, var(--tw-ring-opacity));
+  }
+
+  .md\:focus\:ring-primary-coral:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(237, 103, 101, var(--tw-ring-opacity));
+  }
+
+  .md\:focus\:ring-primary-green:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(39, 123, 62, var(--tw-ring-opacity));
+  }
+
+  .md\:focus\:ring-primary-green-dark:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(27, 84, 42, var(--tw-ring-opacity));
+  }
+
+  .md\:focus\:ring-primary-green-light:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(51, 162, 82, var(--tw-ring-opacity));
+  }
+
+  .md\:focus\:ring-primary-pink:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(231, 69, 119, var(--tw-ring-opacity));
+  }
+
+  .md\:focus\:ring-primary-purple:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 53, 183, var(--tw-ring-opacity));
+  }
+
+  .md\:focus\:ring-primary-purple-hashita:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 93, 138, var(--tw-ring-opacity));
+  }
+
+  .md\:focus\:ring-primary-red:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(174, 0, 2, var(--tw-ring-opacity));
+  }
+
+  .md\:focus\:ring-primary-red-dark:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(123, 0, 1, var(--tw-ring-opacity));
+  }
+
+  .md\:focus\:ring-primary-red-light:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(225, 0, 3, var(--tw-ring-opacity));
+  }
+
+  .md\:focus\:ring-primary-valencia:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(210, 67, 67, var(--tw-ring-opacity));
+  }
+
+  .md\:focus\:ring-primary-vampire:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(181, 19, 19, var(--tw-ring-opacity));
+  }
+}
+
+@media (min-width: 1024px) {
+  .lg\:order-last {
+    -webkit-box-ordinal-group: 10000;
+    -ms-flex-order: 9999;
+    order: 9999;
+  }
+
+  .lg\:mx-0 {
+    margin-left: 0px;
+    margin-right: 0px;
+  }
+
+  .lg\:mx-auto {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .lg\:mt-0 {
+    margin-top: 0px;
+  }
+
+  .lg\:mt-3 {
+    margin-top: 0.75rem;
+  }
+
+  .lg\:-mt-32 {
+    margin-top: -8rem;
+  }
+
+  .lg\:ml-0 {
+    margin-left: 0px;
+  }
+
+  .lg\:block {
+    display: block;
+  }
+
+  .lg\:flex {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+  }
+
+  .lg\:hidden {
+    display: none;
+  }
+
+  .lg\:h-4 {
+    height: 1rem;
+  }
+
+  .lg\:h-6 {
+    height: 1.5rem;
+  }
+
+  .lg\:w-64 {
+    width: 16rem;
+  }
+
+  .lg\:w-auto {
+    width: auto;
+  }
+
+  .lg\:w-1\/3 {
+    width: 33.333333%;
+  }
+
+  .lg\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .lg\:flex-row {
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+
+  .lg\:flex-col {
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+
+  .lg\:items-center {
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+  }
+
+  .lg\:gap-x-8 {
+    -webkit-column-gap: 2rem;
+    -moz-column-gap: 2rem;
+    column-gap: 2rem;
+  }
+
+  .lg\:bg-transparent {
+    background-color: transparent;
+  }
+
+  .lg\:bg-gradient-to-t {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  }
+
+  .lg\:bg-gradient-to-tr {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+  }
+
+  .lg\:bg-gradient-to-r {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  }
+
+  .lg\:bg-gradient-to-br {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(
+      to bottom right,
+      var(--tw-gradient-stops)
+    );
+  }
+
+  .lg\:bg-gradient-to-b {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+  }
+
+  .lg\:bg-gradient-to-bl {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+  }
+
+  .lg\:bg-gradient-to-l {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to left, var(--tw-gradient-stops));
+  }
+
+  .lg\:bg-gradient-to-tl {
+    background-image: -webkit-gradient(
+      linear,
+      right bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+  }
+
+  .lg\:bg-gradient-boatBlue {
+    background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+  }
+
+  .lg\:bg-gradient-cobalt {
+    background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+  }
+
+  .lg\:bg-gradient-dark {
+    background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+  }
+
+  .lg\:bg-gradient-harold {
+    background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+  }
+
+  .lg\:bg-gradient-full {
+    background-image: linear-gradient(
+      -225deg,
+      #ec857c 0%,
+      #cc3566 26%,
+      #df7f75 47%,
+      #90399e 66%,
+      #5d5cbd 83%,
+      #2f97d9 100%
+    );
+  }
+
+  .lg\:bg-gradient-green {
+    background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+  }
+
+  .lg\:bg-gradient-pink {
+    background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+  }
+
+  .lg\:bg-gradient-purple {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#8631a0),
+      to(#360b4c)
+    );
+    background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  }
+
+  .lg\:bg-gradient-red {
+    background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+  }
+
+  .lg\:focus-within\:bg-gradient-to-t:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  }
+
+  .lg\:focus-within\:bg-gradient-to-tr:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+  }
+
+  .lg\:focus-within\:bg-gradient-to-r:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  }
+
+  .lg\:focus-within\:bg-gradient-to-br:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(
+      to bottom right,
+      var(--tw-gradient-stops)
+    );
+  }
+
+  .lg\:focus-within\:bg-gradient-to-b:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+  }
+
+  .lg\:focus-within\:bg-gradient-to-bl:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+  }
+
+  .lg\:focus-within\:bg-gradient-to-l:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to left, var(--tw-gradient-stops));
+  }
+
+  .lg\:focus-within\:bg-gradient-to-tl:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      right bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+  }
+
+  .lg\:focus-within\:bg-gradient-boatBlue:focus-within {
+    background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+  }
+
+  .lg\:focus-within\:bg-gradient-cobalt:focus-within {
+    background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+  }
+
+  .lg\:focus-within\:bg-gradient-dark:focus-within {
+    background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+  }
+
+  .lg\:focus-within\:bg-gradient-harold:focus-within {
+    background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+  }
+
+  .lg\:focus-within\:bg-gradient-full:focus-within {
+    background-image: linear-gradient(
+      -225deg,
+      #ec857c 0%,
+      #cc3566 26%,
+      #df7f75 47%,
+      #90399e 66%,
+      #5d5cbd 83%,
+      #2f97d9 100%
+    );
+  }
+
+  .lg\:focus-within\:bg-gradient-green:focus-within {
+    background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+  }
+
+  .lg\:focus-within\:bg-gradient-pink:focus-within {
+    background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+  }
+
+  .lg\:focus-within\:bg-gradient-purple:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#8631a0),
+      to(#360b4c)
+    );
+    background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  }
+
+  .lg\:focus-within\:bg-gradient-red:focus-within {
+    background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+  }
+
+  .lg\:hover\:bg-gradient-to-t:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  }
+
+  .lg\:hover\:bg-gradient-to-tr:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+  }
+
+  .lg\:hover\:bg-gradient-to-r:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  }
+
+  .lg\:hover\:bg-gradient-to-br:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(
+      to bottom right,
+      var(--tw-gradient-stops)
+    );
+  }
+
+  .lg\:hover\:bg-gradient-to-b:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+  }
+
+  .lg\:hover\:bg-gradient-to-bl:hover {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+  }
+
+  .lg\:hover\:bg-gradient-to-l:hover {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to left, var(--tw-gradient-stops));
+  }
+
+  .lg\:hover\:bg-gradient-to-tl:hover {
+    background-image: -webkit-gradient(
+      linear,
+      right bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+  }
+
+  .lg\:hover\:bg-gradient-boatBlue:hover {
+    background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+  }
+
+  .lg\:hover\:bg-gradient-cobalt:hover {
+    background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+  }
+
+  .lg\:hover\:bg-gradient-dark:hover {
+    background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+  }
+
+  .lg\:hover\:bg-gradient-harold:hover {
+    background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+  }
+
+  .lg\:hover\:bg-gradient-full:hover {
+    background-image: linear-gradient(
+      -225deg,
+      #ec857c 0%,
+      #cc3566 26%,
+      #df7f75 47%,
+      #90399e 66%,
+      #5d5cbd 83%,
+      #2f97d9 100%
+    );
+  }
+
+  .lg\:hover\:bg-gradient-green:hover {
+    background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+  }
+
+  .lg\:hover\:bg-gradient-pink:hover {
+    background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+  }
+
+  .lg\:hover\:bg-gradient-purple:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#8631a0),
+      to(#360b4c)
+    );
+    background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  }
+
+  .lg\:hover\:bg-gradient-red:hover {
+    background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+  }
+
+  .lg\:disabled\:bg-gradient-to-t:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  }
+
+  .lg\:disabled\:bg-gradient-to-tr:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+  }
+
+  .lg\:disabled\:bg-gradient-to-r:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  }
+
+  .lg\:disabled\:bg-gradient-to-br:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(
+      to bottom right,
+      var(--tw-gradient-stops)
+    );
+  }
+
+  .lg\:disabled\:bg-gradient-to-b:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+  }
+
+  .lg\:disabled\:bg-gradient-to-bl:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+  }
+
+  .lg\:disabled\:bg-gradient-to-l:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to left, var(--tw-gradient-stops));
+  }
+
+  .lg\:disabled\:bg-gradient-to-tl:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      right bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+  }
+
+  .lg\:disabled\:bg-gradient-boatBlue:disabled {
+    background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+  }
+
+  .lg\:disabled\:bg-gradient-cobalt:disabled {
+    background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+  }
+
+  .lg\:disabled\:bg-gradient-dark:disabled {
+    background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+  }
+
+  .lg\:disabled\:bg-gradient-harold:disabled {
+    background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+  }
+
+  .lg\:disabled\:bg-gradient-full:disabled {
+    background-image: linear-gradient(
+      -225deg,
+      #ec857c 0%,
+      #cc3566 26%,
+      #df7f75 47%,
+      #90399e 66%,
+      #5d5cbd 83%,
+      #2f97d9 100%
+    );
+  }
+
+  .lg\:disabled\:bg-gradient-green:disabled {
+    background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+  }
+
+  .lg\:disabled\:bg-gradient-pink:disabled {
+    background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+  }
+
+  .lg\:disabled\:bg-gradient-purple:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#8631a0),
+      to(#360b4c)
+    );
+    background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  }
+
+  .lg\:disabled\:bg-gradient-red:disabled {
+    background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+  }
+
+  .lg\:p-0 {
+    padding: 0px;
+  }
+
+  .lg\:p-6 {
+    padding: 1.5rem;
+  }
+
+  .lg\:px-11 {
+    padding-left: 2.75rem;
+    padding-right: 2.75rem;
+  }
+
+  .lg\:pt-5 {
+    padding-top: 1.25rem;
+  }
+
+  .lg\:text-sm {
+    font-size: 0.875rem;
+    line-height: 1.3125rem;
+  }
+
+  .lg\:text-lg {
+    font-size: 1.125rem;
+    line-height: 1.6875rem;
+  }
+
+  .lg\:text-2xl {
+    font-size: 1.375rem;
+    line-height: 2.0625rem;
+  }
+
+  .lg\:text-4xl {
+    font-size: 1.625rem;
+    line-height: 2.4375rem;
+  }
+
+  .lg\:ring-primary-blue {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(40, 131, 251, var(--tw-ring-opacity));
+  }
+
+  .lg\:ring-primary-boatBlue {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(43, 82, 131, var(--tw-ring-opacity));
+  }
+
+  .lg\:ring-primary-boatBlue-dark {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(30, 58, 93, var(--tw-ring-opacity));
+  }
+
+  .lg\:ring-primary-boatBlue-light {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(56, 106, 169, var(--tw-ring-opacity));
+  }
+
+  .lg\:ring-primary-cobalt {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(49, 50, 131, var(--tw-ring-opacity));
+  }
+
+  .lg\:ring-primary-cobalt-dark {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(35, 36, 94, var(--tw-ring-opacity));
+  }
+
+  .lg\:ring-primary-cobalt-light {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(63, 64, 168, var(--tw-ring-opacity));
+  }
+
+  .lg\:ring-primary-coral {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(237, 103, 101, var(--tw-ring-opacity));
+  }
+
+  .lg\:ring-primary-green {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(39, 123, 62, var(--tw-ring-opacity));
+  }
+
+  .lg\:ring-primary-green-dark {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(27, 84, 42, var(--tw-ring-opacity));
+  }
+
+  .lg\:ring-primary-green-light {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(51, 162, 82, var(--tw-ring-opacity));
+  }
+
+  .lg\:ring-primary-pink {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(231, 69, 119, var(--tw-ring-opacity));
+  }
+
+  .lg\:ring-primary-purple {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 53, 183, var(--tw-ring-opacity));
+  }
+
+  .lg\:ring-primary-purple-hashita {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 93, 138, var(--tw-ring-opacity));
+  }
+
+  .lg\:ring-primary-red {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(174, 0, 2, var(--tw-ring-opacity));
+  }
+
+  .lg\:ring-primary-red-dark {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(123, 0, 1, var(--tw-ring-opacity));
+  }
+
+  .lg\:ring-primary-red-light {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(225, 0, 3, var(--tw-ring-opacity));
+  }
+
+  .lg\:ring-primary-valencia {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(210, 67, 67, var(--tw-ring-opacity));
+  }
+
+  .lg\:ring-primary-vampire {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(181, 19, 19, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus-within\:ring-primary-blue:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(40, 131, 251, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus-within\:ring-primary-boatBlue:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(43, 82, 131, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus-within\:ring-primary-boatBlue-dark:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(30, 58, 93, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus-within\:ring-primary-boatBlue-light:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(56, 106, 169, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus-within\:ring-primary-cobalt:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(49, 50, 131, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus-within\:ring-primary-cobalt-dark:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(35, 36, 94, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus-within\:ring-primary-cobalt-light:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(63, 64, 168, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus-within\:ring-primary-coral:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(237, 103, 101, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus-within\:ring-primary-green:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(39, 123, 62, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus-within\:ring-primary-green-dark:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(27, 84, 42, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus-within\:ring-primary-green-light:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(51, 162, 82, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus-within\:ring-primary-pink:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(231, 69, 119, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus-within\:ring-primary-purple:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 53, 183, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus-within\:ring-primary-purple-hashita:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 93, 138, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus-within\:ring-primary-red:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(174, 0, 2, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus-within\:ring-primary-red-dark:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(123, 0, 1, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus-within\:ring-primary-red-light:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(225, 0, 3, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus-within\:ring-primary-valencia:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(210, 67, 67, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus-within\:ring-primary-vampire:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(181, 19, 19, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus\:ring-primary-blue:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(40, 131, 251, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus\:ring-primary-boatBlue:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(43, 82, 131, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus\:ring-primary-boatBlue-dark:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(30, 58, 93, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus\:ring-primary-boatBlue-light:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(56, 106, 169, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus\:ring-primary-cobalt:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(49, 50, 131, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus\:ring-primary-cobalt-dark:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(35, 36, 94, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus\:ring-primary-cobalt-light:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(63, 64, 168, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus\:ring-primary-coral:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(237, 103, 101, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus\:ring-primary-green:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(39, 123, 62, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus\:ring-primary-green-dark:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(27, 84, 42, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus\:ring-primary-green-light:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(51, 162, 82, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus\:ring-primary-pink:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(231, 69, 119, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus\:ring-primary-purple:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 53, 183, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus\:ring-primary-purple-hashita:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 93, 138, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus\:ring-primary-red:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(174, 0, 2, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus\:ring-primary-red-dark:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(123, 0, 1, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus\:ring-primary-red-light:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(225, 0, 3, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus\:ring-primary-valencia:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(210, 67, 67, var(--tw-ring-opacity));
+  }
+
+  .lg\:focus\:ring-primary-vampire:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(181, 19, 19, var(--tw-ring-opacity));
+  }
+}
+
+@media (min-width: 1280px) {
+  .xl\:w-64 {
+    width: 16rem;
+  }
+
+  .xl\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .xl\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .xl\:gap-8 {
+    gap: 2rem;
+  }
+
+  .xl\:bg-gradient-to-t {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  }
+
+  .xl\:bg-gradient-to-tr {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+  }
+
+  .xl\:bg-gradient-to-r {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  }
+
+  .xl\:bg-gradient-to-br {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(
+      to bottom right,
+      var(--tw-gradient-stops)
+    );
+  }
+
+  .xl\:bg-gradient-to-b {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+  }
+
+  .xl\:bg-gradient-to-bl {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+  }
+
+  .xl\:bg-gradient-to-l {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to left, var(--tw-gradient-stops));
+  }
+
+  .xl\:bg-gradient-to-tl {
+    background-image: -webkit-gradient(
+      linear,
+      right bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+  }
+
+  .xl\:bg-gradient-boatBlue {
+    background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+  }
+
+  .xl\:bg-gradient-cobalt {
+    background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+  }
+
+  .xl\:bg-gradient-dark {
+    background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+  }
+
+  .xl\:bg-gradient-harold {
+    background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+  }
+
+  .xl\:bg-gradient-full {
+    background-image: linear-gradient(
+      -225deg,
+      #ec857c 0%,
+      #cc3566 26%,
+      #df7f75 47%,
+      #90399e 66%,
+      #5d5cbd 83%,
+      #2f97d9 100%
+    );
+  }
+
+  .xl\:bg-gradient-green {
+    background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+  }
+
+  .xl\:bg-gradient-pink {
+    background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+  }
+
+  .xl\:bg-gradient-purple {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#8631a0),
+      to(#360b4c)
+    );
+    background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  }
+
+  .xl\:bg-gradient-red {
+    background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+  }
+
+  .xl\:focus-within\:bg-gradient-to-t:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  }
+
+  .xl\:focus-within\:bg-gradient-to-tr:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+  }
+
+  .xl\:focus-within\:bg-gradient-to-r:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  }
+
+  .xl\:focus-within\:bg-gradient-to-br:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(
+      to bottom right,
+      var(--tw-gradient-stops)
+    );
+  }
+
+  .xl\:focus-within\:bg-gradient-to-b:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+  }
+
+  .xl\:focus-within\:bg-gradient-to-bl:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+  }
+
+  .xl\:focus-within\:bg-gradient-to-l:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to left, var(--tw-gradient-stops));
+  }
+
+  .xl\:focus-within\:bg-gradient-to-tl:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      right bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+  }
+
+  .xl\:focus-within\:bg-gradient-boatBlue:focus-within {
+    background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+  }
+
+  .xl\:focus-within\:bg-gradient-cobalt:focus-within {
+    background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+  }
+
+  .xl\:focus-within\:bg-gradient-dark:focus-within {
+    background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+  }
+
+  .xl\:focus-within\:bg-gradient-harold:focus-within {
+    background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+  }
+
+  .xl\:focus-within\:bg-gradient-full:focus-within {
+    background-image: linear-gradient(
+      -225deg,
+      #ec857c 0%,
+      #cc3566 26%,
+      #df7f75 47%,
+      #90399e 66%,
+      #5d5cbd 83%,
+      #2f97d9 100%
+    );
+  }
+
+  .xl\:focus-within\:bg-gradient-green:focus-within {
+    background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+  }
+
+  .xl\:focus-within\:bg-gradient-pink:focus-within {
+    background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+  }
+
+  .xl\:focus-within\:bg-gradient-purple:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#8631a0),
+      to(#360b4c)
+    );
+    background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  }
+
+  .xl\:focus-within\:bg-gradient-red:focus-within {
+    background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+  }
+
+  .xl\:hover\:bg-gradient-to-t:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  }
+
+  .xl\:hover\:bg-gradient-to-tr:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+  }
+
+  .xl\:hover\:bg-gradient-to-r:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  }
+
+  .xl\:hover\:bg-gradient-to-br:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(
+      to bottom right,
+      var(--tw-gradient-stops)
+    );
+  }
+
+  .xl\:hover\:bg-gradient-to-b:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+  }
+
+  .xl\:hover\:bg-gradient-to-bl:hover {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+  }
+
+  .xl\:hover\:bg-gradient-to-l:hover {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to left, var(--tw-gradient-stops));
+  }
+
+  .xl\:hover\:bg-gradient-to-tl:hover {
+    background-image: -webkit-gradient(
+      linear,
+      right bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+  }
+
+  .xl\:hover\:bg-gradient-boatBlue:hover {
+    background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+  }
+
+  .xl\:hover\:bg-gradient-cobalt:hover {
+    background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+  }
+
+  .xl\:hover\:bg-gradient-dark:hover {
+    background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+  }
+
+  .xl\:hover\:bg-gradient-harold:hover {
+    background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+  }
+
+  .xl\:hover\:bg-gradient-full:hover {
+    background-image: linear-gradient(
+      -225deg,
+      #ec857c 0%,
+      #cc3566 26%,
+      #df7f75 47%,
+      #90399e 66%,
+      #5d5cbd 83%,
+      #2f97d9 100%
+    );
+  }
+
+  .xl\:hover\:bg-gradient-green:hover {
+    background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+  }
+
+  .xl\:hover\:bg-gradient-pink:hover {
+    background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+  }
+
+  .xl\:hover\:bg-gradient-purple:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#8631a0),
+      to(#360b4c)
+    );
+    background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  }
+
+  .xl\:hover\:bg-gradient-red:hover {
+    background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+  }
+
+  .xl\:disabled\:bg-gradient-to-t:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  }
+
+  .xl\:disabled\:bg-gradient-to-tr:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+  }
+
+  .xl\:disabled\:bg-gradient-to-r:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  }
+
+  .xl\:disabled\:bg-gradient-to-br:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(
+      to bottom right,
+      var(--tw-gradient-stops)
+    );
+  }
+
+  .xl\:disabled\:bg-gradient-to-b:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+  }
+
+  .xl\:disabled\:bg-gradient-to-bl:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+  }
+
+  .xl\:disabled\:bg-gradient-to-l:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to left, var(--tw-gradient-stops));
+  }
+
+  .xl\:disabled\:bg-gradient-to-tl:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      right bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+  }
+
+  .xl\:disabled\:bg-gradient-boatBlue:disabled {
+    background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+  }
+
+  .xl\:disabled\:bg-gradient-cobalt:disabled {
+    background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+  }
+
+  .xl\:disabled\:bg-gradient-dark:disabled {
+    background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+  }
+
+  .xl\:disabled\:bg-gradient-harold:disabled {
+    background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+  }
+
+  .xl\:disabled\:bg-gradient-full:disabled {
+    background-image: linear-gradient(
+      -225deg,
+      #ec857c 0%,
+      #cc3566 26%,
+      #df7f75 47%,
+      #90399e 66%,
+      #5d5cbd 83%,
+      #2f97d9 100%
+    );
+  }
+
+  .xl\:disabled\:bg-gradient-green:disabled {
+    background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+  }
+
+  .xl\:disabled\:bg-gradient-pink:disabled {
+    background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+  }
+
+  .xl\:disabled\:bg-gradient-purple:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#8631a0),
+      to(#360b4c)
+    );
+    background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  }
+
+  .xl\:disabled\:bg-gradient-red:disabled {
+    background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+  }
+
+  .xl\:ring-primary-blue {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(40, 131, 251, var(--tw-ring-opacity));
+  }
+
+  .xl\:ring-primary-boatBlue {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(43, 82, 131, var(--tw-ring-opacity));
+  }
+
+  .xl\:ring-primary-boatBlue-dark {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(30, 58, 93, var(--tw-ring-opacity));
+  }
+
+  .xl\:ring-primary-boatBlue-light {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(56, 106, 169, var(--tw-ring-opacity));
+  }
+
+  .xl\:ring-primary-cobalt {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(49, 50, 131, var(--tw-ring-opacity));
+  }
+
+  .xl\:ring-primary-cobalt-dark {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(35, 36, 94, var(--tw-ring-opacity));
+  }
+
+  .xl\:ring-primary-cobalt-light {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(63, 64, 168, var(--tw-ring-opacity));
+  }
+
+  .xl\:ring-primary-coral {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(237, 103, 101, var(--tw-ring-opacity));
+  }
+
+  .xl\:ring-primary-green {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(39, 123, 62, var(--tw-ring-opacity));
+  }
+
+  .xl\:ring-primary-green-dark {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(27, 84, 42, var(--tw-ring-opacity));
+  }
+
+  .xl\:ring-primary-green-light {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(51, 162, 82, var(--tw-ring-opacity));
+  }
+
+  .xl\:ring-primary-pink {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(231, 69, 119, var(--tw-ring-opacity));
+  }
+
+  .xl\:ring-primary-purple {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 53, 183, var(--tw-ring-opacity));
+  }
+
+  .xl\:ring-primary-purple-hashita {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 93, 138, var(--tw-ring-opacity));
+  }
+
+  .xl\:ring-primary-red {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(174, 0, 2, var(--tw-ring-opacity));
+  }
+
+  .xl\:ring-primary-red-dark {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(123, 0, 1, var(--tw-ring-opacity));
+  }
+
+  .xl\:ring-primary-red-light {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(225, 0, 3, var(--tw-ring-opacity));
+  }
+
+  .xl\:ring-primary-valencia {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(210, 67, 67, var(--tw-ring-opacity));
+  }
+
+  .xl\:ring-primary-vampire {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(181, 19, 19, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus-within\:ring-primary-blue:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(40, 131, 251, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus-within\:ring-primary-boatBlue:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(43, 82, 131, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus-within\:ring-primary-boatBlue-dark:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(30, 58, 93, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus-within\:ring-primary-boatBlue-light:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(56, 106, 169, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus-within\:ring-primary-cobalt:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(49, 50, 131, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus-within\:ring-primary-cobalt-dark:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(35, 36, 94, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus-within\:ring-primary-cobalt-light:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(63, 64, 168, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus-within\:ring-primary-coral:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(237, 103, 101, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus-within\:ring-primary-green:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(39, 123, 62, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus-within\:ring-primary-green-dark:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(27, 84, 42, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus-within\:ring-primary-green-light:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(51, 162, 82, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus-within\:ring-primary-pink:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(231, 69, 119, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus-within\:ring-primary-purple:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 53, 183, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus-within\:ring-primary-purple-hashita:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 93, 138, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus-within\:ring-primary-red:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(174, 0, 2, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus-within\:ring-primary-red-dark:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(123, 0, 1, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus-within\:ring-primary-red-light:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(225, 0, 3, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus-within\:ring-primary-valencia:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(210, 67, 67, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus-within\:ring-primary-vampire:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(181, 19, 19, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus\:ring-primary-blue:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(40, 131, 251, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus\:ring-primary-boatBlue:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(43, 82, 131, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus\:ring-primary-boatBlue-dark:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(30, 58, 93, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus\:ring-primary-boatBlue-light:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(56, 106, 169, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus\:ring-primary-cobalt:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(49, 50, 131, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus\:ring-primary-cobalt-dark:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(35, 36, 94, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus\:ring-primary-cobalt-light:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(63, 64, 168, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus\:ring-primary-coral:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(237, 103, 101, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus\:ring-primary-green:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(39, 123, 62, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus\:ring-primary-green-dark:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(27, 84, 42, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus\:ring-primary-green-light:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(51, 162, 82, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus\:ring-primary-pink:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(231, 69, 119, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus\:ring-primary-purple:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 53, 183, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus\:ring-primary-purple-hashita:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 93, 138, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus\:ring-primary-red:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(174, 0, 2, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus\:ring-primary-red-dark:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(123, 0, 1, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus\:ring-primary-red-light:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(225, 0, 3, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus\:ring-primary-valencia:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(210, 67, 67, var(--tw-ring-opacity));
+  }
+
+  .xl\:focus\:ring-primary-vampire:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(181, 19, 19, var(--tw-ring-opacity));
+  }
+}
+
+@media (min-width: 1536px) {
+  .\32xl\:bg-gradient-to-t {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:bg-gradient-to-tr {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:bg-gradient-to-r {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:bg-gradient-to-br {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(
+      to bottom right,
+      var(--tw-gradient-stops)
+    );
+  }
+
+  .\32xl\:bg-gradient-to-b {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:bg-gradient-to-bl {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:bg-gradient-to-l {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to left, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:bg-gradient-to-tl {
+    background-image: -webkit-gradient(
+      linear,
+      right bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:bg-gradient-boatBlue {
+    background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+  }
+
+  .\32xl\:bg-gradient-cobalt {
+    background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+  }
+
+  .\32xl\:bg-gradient-dark {
+    background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+  }
+
+  .\32xl\:bg-gradient-harold {
+    background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+  }
+
+  .\32xl\:bg-gradient-full {
+    background-image: linear-gradient(
+      -225deg,
+      #ec857c 0%,
+      #cc3566 26%,
+      #df7f75 47%,
+      #90399e 66%,
+      #5d5cbd 83%,
+      #2f97d9 100%
+    );
+  }
+
+  .\32xl\:bg-gradient-green {
+    background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+  }
+
+  .\32xl\:bg-gradient-pink {
+    background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+  }
+
+  .\32xl\:bg-gradient-purple {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#8631a0),
+      to(#360b4c)
+    );
+    background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  }
+
+  .\32xl\:bg-gradient-red {
+    background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+  }
+
+  .\32xl\:focus-within\:bg-gradient-to-t:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:focus-within\:bg-gradient-to-tr:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:focus-within\:bg-gradient-to-r:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:focus-within\:bg-gradient-to-br:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(
+      to bottom right,
+      var(--tw-gradient-stops)
+    );
+  }
+
+  .\32xl\:focus-within\:bg-gradient-to-b:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:focus-within\:bg-gradient-to-bl:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:focus-within\:bg-gradient-to-l:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to left, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:focus-within\:bg-gradient-to-tl:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      right bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:focus-within\:bg-gradient-boatBlue:focus-within {
+    background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+  }
+
+  .\32xl\:focus-within\:bg-gradient-cobalt:focus-within {
+    background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+  }
+
+  .\32xl\:focus-within\:bg-gradient-dark:focus-within {
+    background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+  }
+
+  .\32xl\:focus-within\:bg-gradient-harold:focus-within {
+    background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+  }
+
+  .\32xl\:focus-within\:bg-gradient-full:focus-within {
+    background-image: linear-gradient(
+      -225deg,
+      #ec857c 0%,
+      #cc3566 26%,
+      #df7f75 47%,
+      #90399e 66%,
+      #5d5cbd 83%,
+      #2f97d9 100%
+    );
+  }
+
+  .\32xl\:focus-within\:bg-gradient-green:focus-within {
+    background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+  }
+
+  .\32xl\:focus-within\:bg-gradient-pink:focus-within {
+    background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+  }
+
+  .\32xl\:focus-within\:bg-gradient-purple:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#8631a0),
+      to(#360b4c)
+    );
+    background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  }
+
+  .\32xl\:focus-within\:bg-gradient-red:focus-within {
+    background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+  }
+
+  .\32xl\:hover\:bg-gradient-to-t:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:hover\:bg-gradient-to-tr:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:hover\:bg-gradient-to-r:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:hover\:bg-gradient-to-br:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(
+      to bottom right,
+      var(--tw-gradient-stops)
+    );
+  }
+
+  .\32xl\:hover\:bg-gradient-to-b:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:hover\:bg-gradient-to-bl:hover {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:hover\:bg-gradient-to-l:hover {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to left, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:hover\:bg-gradient-to-tl:hover {
+    background-image: -webkit-gradient(
+      linear,
+      right bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:hover\:bg-gradient-boatBlue:hover {
+    background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+  }
+
+  .\32xl\:hover\:bg-gradient-cobalt:hover {
+    background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+  }
+
+  .\32xl\:hover\:bg-gradient-dark:hover {
+    background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+  }
+
+  .\32xl\:hover\:bg-gradient-harold:hover {
+    background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+  }
+
+  .\32xl\:hover\:bg-gradient-full:hover {
+    background-image: linear-gradient(
+      -225deg,
+      #ec857c 0%,
+      #cc3566 26%,
+      #df7f75 47%,
+      #90399e 66%,
+      #5d5cbd 83%,
+      #2f97d9 100%
+    );
+  }
+
+  .\32xl\:hover\:bg-gradient-green:hover {
+    background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+  }
+
+  .\32xl\:hover\:bg-gradient-pink:hover {
+    background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+  }
+
+  .\32xl\:hover\:bg-gradient-purple:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#8631a0),
+      to(#360b4c)
+    );
+    background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  }
+
+  .\32xl\:hover\:bg-gradient-red:hover {
+    background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+  }
+
+  .\32xl\:disabled\:bg-gradient-to-t:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:disabled\:bg-gradient-to-tr:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:disabled\:bg-gradient-to-r:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:disabled\:bg-gradient-to-br:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(
+      to bottom right,
+      var(--tw-gradient-stops)
+    );
+  }
+
+  .\32xl\:disabled\:bg-gradient-to-b:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:disabled\:bg-gradient-to-bl:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:disabled\:bg-gradient-to-l:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to left, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:disabled\:bg-gradient-to-tl:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      right bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+  }
+
+  .\32xl\:disabled\:bg-gradient-boatBlue:disabled {
+    background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+  }
+
+  .\32xl\:disabled\:bg-gradient-cobalt:disabled {
+    background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+  }
+
+  .\32xl\:disabled\:bg-gradient-dark:disabled {
+    background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+  }
+
+  .\32xl\:disabled\:bg-gradient-harold:disabled {
+    background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+  }
+
+  .\32xl\:disabled\:bg-gradient-full:disabled {
+    background-image: linear-gradient(
+      -225deg,
+      #ec857c 0%,
+      #cc3566 26%,
+      #df7f75 47%,
+      #90399e 66%,
+      #5d5cbd 83%,
+      #2f97d9 100%
+    );
+  }
+
+  .\32xl\:disabled\:bg-gradient-green:disabled {
+    background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+  }
+
+  .\32xl\:disabled\:bg-gradient-pink:disabled {
+    background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+  }
+
+  .\32xl\:disabled\:bg-gradient-purple:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#8631a0),
+      to(#360b4c)
+    );
+    background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  }
+
+  .\32xl\:disabled\:bg-gradient-red:disabled {
+    background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+  }
+
+  .\32xl\:ring-primary-blue {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(40, 131, 251, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:ring-primary-boatBlue {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(43, 82, 131, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:ring-primary-boatBlue-dark {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(30, 58, 93, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:ring-primary-boatBlue-light {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(56, 106, 169, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:ring-primary-cobalt {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(49, 50, 131, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:ring-primary-cobalt-dark {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(35, 36, 94, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:ring-primary-cobalt-light {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(63, 64, 168, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:ring-primary-coral {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(237, 103, 101, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:ring-primary-green {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(39, 123, 62, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:ring-primary-green-dark {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(27, 84, 42, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:ring-primary-green-light {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(51, 162, 82, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:ring-primary-pink {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(231, 69, 119, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:ring-primary-purple {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 53, 183, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:ring-primary-purple-hashita {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 93, 138, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:ring-primary-red {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(174, 0, 2, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:ring-primary-red-dark {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(123, 0, 1, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:ring-primary-red-light {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(225, 0, 3, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:ring-primary-valencia {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(210, 67, 67, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:ring-primary-vampire {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(181, 19, 19, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus-within\:ring-primary-blue:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(40, 131, 251, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus-within\:ring-primary-boatBlue:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(43, 82, 131, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus-within\:ring-primary-boatBlue-dark:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(30, 58, 93, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus-within\:ring-primary-boatBlue-light:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(56, 106, 169, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus-within\:ring-primary-cobalt:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(49, 50, 131, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus-within\:ring-primary-cobalt-dark:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(35, 36, 94, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus-within\:ring-primary-cobalt-light:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(63, 64, 168, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus-within\:ring-primary-coral:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(237, 103, 101, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus-within\:ring-primary-green:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(39, 123, 62, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus-within\:ring-primary-green-dark:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(27, 84, 42, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus-within\:ring-primary-green-light:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(51, 162, 82, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus-within\:ring-primary-pink:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(231, 69, 119, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus-within\:ring-primary-purple:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 53, 183, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus-within\:ring-primary-purple-hashita:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 93, 138, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus-within\:ring-primary-red:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(174, 0, 2, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus-within\:ring-primary-red-dark:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(123, 0, 1, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus-within\:ring-primary-red-light:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(225, 0, 3, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus-within\:ring-primary-valencia:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(210, 67, 67, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus-within\:ring-primary-vampire:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(181, 19, 19, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus\:ring-primary-blue:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(40, 131, 251, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus\:ring-primary-boatBlue:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(43, 82, 131, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus\:ring-primary-boatBlue-dark:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(30, 58, 93, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus\:ring-primary-boatBlue-light:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(56, 106, 169, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus\:ring-primary-cobalt:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(49, 50, 131, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus\:ring-primary-cobalt-dark:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(35, 36, 94, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus\:ring-primary-cobalt-light:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(63, 64, 168, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus\:ring-primary-coral:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(237, 103, 101, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus\:ring-primary-green:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(39, 123, 62, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus\:ring-primary-green-dark:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(27, 84, 42, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus\:ring-primary-green-light:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(51, 162, 82, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus\:ring-primary-pink:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(231, 69, 119, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus\:ring-primary-purple:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 53, 183, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus\:ring-primary-purple-hashita:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 93, 138, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus\:ring-primary-red:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(174, 0, 2, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus\:ring-primary-red-dark:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(123, 0, 1, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus\:ring-primary-red-light:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(225, 0, 3, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus\:ring-primary-valencia:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(210, 67, 67, var(--tw-ring-opacity));
+  }
+
+  .\32xl\:focus\:ring-primary-vampire:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(181, 19, 19, var(--tw-ring-opacity));
+  }
+}
+
+@media (min-width: 350px) {
+  .xs\:flex-none {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+  }
+
+  .xs\:bg-gradient-to-t {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  }
+
+  .xs\:bg-gradient-to-tr {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+  }
+
+  .xs\:bg-gradient-to-r {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  }
+
+  .xs\:bg-gradient-to-br {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(
+      to bottom right,
+      var(--tw-gradient-stops)
+    );
+  }
+
+  .xs\:bg-gradient-to-b {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+  }
+
+  .xs\:bg-gradient-to-bl {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+  }
+
+  .xs\:bg-gradient-to-l {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to left, var(--tw-gradient-stops));
+  }
+
+  .xs\:bg-gradient-to-tl {
+    background-image: -webkit-gradient(
+      linear,
+      right bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+  }
+
+  .xs\:bg-gradient-boatBlue {
+    background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+  }
+
+  .xs\:bg-gradient-cobalt {
+    background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+  }
+
+  .xs\:bg-gradient-dark {
+    background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+  }
+
+  .xs\:bg-gradient-harold {
+    background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+  }
+
+  .xs\:bg-gradient-full {
+    background-image: linear-gradient(
+      -225deg,
+      #ec857c 0%,
+      #cc3566 26%,
+      #df7f75 47%,
+      #90399e 66%,
+      #5d5cbd 83%,
+      #2f97d9 100%
+    );
+  }
+
+  .xs\:bg-gradient-green {
+    background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+  }
+
+  .xs\:bg-gradient-pink {
+    background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+  }
+
+  .xs\:bg-gradient-purple {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#8631a0),
+      to(#360b4c)
+    );
+    background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  }
+
+  .xs\:bg-gradient-red {
+    background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+  }
+
+  .xs\:focus-within\:bg-gradient-to-t:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  }
+
+  .xs\:focus-within\:bg-gradient-to-tr:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+  }
+
+  .xs\:focus-within\:bg-gradient-to-r:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  }
+
+  .xs\:focus-within\:bg-gradient-to-br:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(
+      to bottom right,
+      var(--tw-gradient-stops)
+    );
+  }
+
+  .xs\:focus-within\:bg-gradient-to-b:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+  }
+
+  .xs\:focus-within\:bg-gradient-to-bl:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+  }
+
+  .xs\:focus-within\:bg-gradient-to-l:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to left, var(--tw-gradient-stops));
+  }
+
+  .xs\:focus-within\:bg-gradient-to-tl:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      right bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+  }
+
+  .xs\:focus-within\:bg-gradient-boatBlue:focus-within {
+    background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+  }
+
+  .xs\:focus-within\:bg-gradient-cobalt:focus-within {
+    background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+  }
+
+  .xs\:focus-within\:bg-gradient-dark:focus-within {
+    background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+  }
+
+  .xs\:focus-within\:bg-gradient-harold:focus-within {
+    background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+  }
+
+  .xs\:focus-within\:bg-gradient-full:focus-within {
+    background-image: linear-gradient(
+      -225deg,
+      #ec857c 0%,
+      #cc3566 26%,
+      #df7f75 47%,
+      #90399e 66%,
+      #5d5cbd 83%,
+      #2f97d9 100%
+    );
+  }
+
+  .xs\:focus-within\:bg-gradient-green:focus-within {
+    background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+  }
+
+  .xs\:focus-within\:bg-gradient-pink:focus-within {
+    background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+  }
+
+  .xs\:focus-within\:bg-gradient-purple:focus-within {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#8631a0),
+      to(#360b4c)
+    );
+    background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  }
+
+  .xs\:focus-within\:bg-gradient-red:focus-within {
+    background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+  }
+
+  .xs\:hover\:bg-gradient-to-t:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  }
+
+  .xs\:hover\:bg-gradient-to-tr:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+  }
+
+  .xs\:hover\:bg-gradient-to-r:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  }
+
+  .xs\:hover\:bg-gradient-to-br:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(
+      to bottom right,
+      var(--tw-gradient-stops)
+    );
+  }
+
+  .xs\:hover\:bg-gradient-to-b:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+  }
+
+  .xs\:hover\:bg-gradient-to-bl:hover {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+  }
+
+  .xs\:hover\:bg-gradient-to-l:hover {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to left, var(--tw-gradient-stops));
+  }
+
+  .xs\:hover\:bg-gradient-to-tl:hover {
+    background-image: -webkit-gradient(
+      linear,
+      right bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+  }
+
+  .xs\:hover\:bg-gradient-boatBlue:hover {
+    background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+  }
+
+  .xs\:hover\:bg-gradient-cobalt:hover {
+    background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+  }
+
+  .xs\:hover\:bg-gradient-dark:hover {
+    background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+  }
+
+  .xs\:hover\:bg-gradient-harold:hover {
+    background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+  }
+
+  .xs\:hover\:bg-gradient-full:hover {
+    background-image: linear-gradient(
+      -225deg,
+      #ec857c 0%,
+      #cc3566 26%,
+      #df7f75 47%,
+      #90399e 66%,
+      #5d5cbd 83%,
+      #2f97d9 100%
+    );
+  }
+
+  .xs\:hover\:bg-gradient-green:hover {
+    background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+  }
+
+  .xs\:hover\:bg-gradient-pink:hover {
+    background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+  }
+
+  .xs\:hover\:bg-gradient-purple:hover {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#8631a0),
+      to(#360b4c)
+    );
+    background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  }
+
+  .xs\:hover\:bg-gradient-red:hover {
+    background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+  }
+
+  .xs\:disabled\:bg-gradient-to-t:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  }
+
+  .xs\:disabled\:bg-gradient-to-tr:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left bottom,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top right, var(--tw-gradient-stops));
+  }
+
+  .xs\:disabled\:bg-gradient-to-r:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to right, var(--tw-gradient-stops));
+  }
+
+  .xs\:disabled\:bg-gradient-to-br:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      right bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(
+      to bottom right,
+      var(--tw-gradient-stops)
+    );
+  }
+
+  .xs\:disabled\:bg-gradient-to-b:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
+  }
+
+  .xs\:disabled\:bg-gradient-to-bl:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left bottom,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to bottom left, var(--tw-gradient-stops));
+  }
+
+  .xs\:disabled\:bg-gradient-to-l:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      right top,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to left, var(--tw-gradient-stops));
+  }
+
+  .xs\:disabled\:bg-gradient-to-tl:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      right bottom,
+      left top,
+      from(var(--tw-gradient-stops))
+    );
+    background-image: linear-gradient(to top left, var(--tw-gradient-stops));
+  }
+
+  .xs\:disabled\:bg-gradient-boatBlue:disabled {
+    background-image: linear-gradient(-225deg, #1e3a5d 0%, #386aa9 100%);
+  }
+
+  .xs\:disabled\:bg-gradient-cobalt:disabled {
+    background-image: linear-gradient(-225deg, #23245e 0%, #3f40a8 100%);
+  }
+
+  .xs\:disabled\:bg-gradient-dark:disabled {
+    background-image: linear-gradient(-135deg, #261131 0%, #100716 100%);
+  }
+
+  .xs\:disabled\:bg-gradient-harold:disabled {
+    background-image: linear-gradient(-135deg, #a095a5 0%, #9e95a3 100%);
+  }
+
+  .xs\:disabled\:bg-gradient-full:disabled {
+    background-image: linear-gradient(
+      -225deg,
+      #ec857c 0%,
+      #cc3566 26%,
+      #df7f75 47%,
+      #90399e 66%,
+      #5d5cbd 83%,
+      #2f97d9 100%
+    );
+  }
+
+  .xs\:disabled\:bg-gradient-green:disabled {
+    background-image: linear-gradient(-225deg, #1b542a 0%, #33a252 100%);
+  }
+
+  .xs\:disabled\:bg-gradient-pink:disabled {
+    background-image: linear-gradient(-135deg, #cd3a67 0%, #49205e 100%);
+  }
+
+  .xs\:disabled\:bg-gradient-purple:disabled {
+    background-image: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#8631a0),
+      to(#360b4c)
+    );
+    background-image: linear-gradient(#8631a0 0%, #360b4c 100%);
+  }
+
+  .xs\:disabled\:bg-gradient-red:disabled {
+    background-image: linear-gradient(-225deg, #7b0001 0%, #e10003 100%);
+  }
+
+  .xs\:text-sm {
+    font-size: 0.875rem;
+    line-height: 1.3125rem;
+  }
+
+  .xs\:text-lg {
+    font-size: 1.125rem;
+    line-height: 1.6875rem;
+  }
+
+  .xs\:ring-primary-blue {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(40, 131, 251, var(--tw-ring-opacity));
+  }
+
+  .xs\:ring-primary-boatBlue {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(43, 82, 131, var(--tw-ring-opacity));
+  }
+
+  .xs\:ring-primary-boatBlue-dark {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(30, 58, 93, var(--tw-ring-opacity));
+  }
+
+  .xs\:ring-primary-boatBlue-light {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(56, 106, 169, var(--tw-ring-opacity));
+  }
+
+  .xs\:ring-primary-cobalt {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(49, 50, 131, var(--tw-ring-opacity));
+  }
+
+  .xs\:ring-primary-cobalt-dark {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(35, 36, 94, var(--tw-ring-opacity));
+  }
+
+  .xs\:ring-primary-cobalt-light {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(63, 64, 168, var(--tw-ring-opacity));
+  }
+
+  .xs\:ring-primary-coral {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(237, 103, 101, var(--tw-ring-opacity));
+  }
+
+  .xs\:ring-primary-green {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(39, 123, 62, var(--tw-ring-opacity));
+  }
+
+  .xs\:ring-primary-green-dark {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(27, 84, 42, var(--tw-ring-opacity));
+  }
+
+  .xs\:ring-primary-green-light {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(51, 162, 82, var(--tw-ring-opacity));
+  }
+
+  .xs\:ring-primary-pink {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(231, 69, 119, var(--tw-ring-opacity));
+  }
+
+  .xs\:ring-primary-purple {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 53, 183, var(--tw-ring-opacity));
+  }
+
+  .xs\:ring-primary-purple-hashita {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 93, 138, var(--tw-ring-opacity));
+  }
+
+  .xs\:ring-primary-red {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(174, 0, 2, var(--tw-ring-opacity));
+  }
+
+  .xs\:ring-primary-red-dark {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(123, 0, 1, var(--tw-ring-opacity));
+  }
+
+  .xs\:ring-primary-red-light {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(225, 0, 3, var(--tw-ring-opacity));
+  }
+
+  .xs\:ring-primary-valencia {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(210, 67, 67, var(--tw-ring-opacity));
+  }
+
+  .xs\:ring-primary-vampire {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(181, 19, 19, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus-within\:ring-primary-blue:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(40, 131, 251, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus-within\:ring-primary-boatBlue:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(43, 82, 131, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus-within\:ring-primary-boatBlue-dark:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(30, 58, 93, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus-within\:ring-primary-boatBlue-light:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(56, 106, 169, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus-within\:ring-primary-cobalt:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(49, 50, 131, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus-within\:ring-primary-cobalt-dark:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(35, 36, 94, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus-within\:ring-primary-cobalt-light:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(63, 64, 168, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus-within\:ring-primary-coral:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(237, 103, 101, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus-within\:ring-primary-green:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(39, 123, 62, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus-within\:ring-primary-green-dark:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(27, 84, 42, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus-within\:ring-primary-green-light:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(51, 162, 82, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus-within\:ring-primary-pink:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(231, 69, 119, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus-within\:ring-primary-purple:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 53, 183, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus-within\:ring-primary-purple-hashita:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 93, 138, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus-within\:ring-primary-red:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(174, 0, 2, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus-within\:ring-primary-red-dark:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(123, 0, 1, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus-within\:ring-primary-red-light:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(225, 0, 3, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus-within\:ring-primary-valencia:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(210, 67, 67, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus-within\:ring-primary-vampire:focus-within {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(181, 19, 19, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus\:ring-primary-blue:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(40, 131, 251, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus\:ring-primary-boatBlue:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(43, 82, 131, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus\:ring-primary-boatBlue-dark:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(30, 58, 93, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus\:ring-primary-boatBlue-light:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(56, 106, 169, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus\:ring-primary-cobalt:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(49, 50, 131, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus\:ring-primary-cobalt-dark:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(35, 36, 94, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus\:ring-primary-cobalt-light:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(63, 64, 168, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus\:ring-primary-coral:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(237, 103, 101, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus\:ring-primary-green:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(39, 123, 62, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus\:ring-primary-green-dark:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(27, 84, 42, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus\:ring-primary-green-light:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(51, 162, 82, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus\:ring-primary-pink:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(231, 69, 119, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus\:ring-primary-purple:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 53, 183, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus\:ring-primary-purple-hashita:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(138, 93, 138, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus\:ring-primary-red:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(174, 0, 2, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus\:ring-primary-red-dark:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(123, 0, 1, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus\:ring-primary-red-light:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(225, 0, 3, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus\:ring-primary-valencia:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(210, 67, 67, var(--tw-ring-opacity));
+  }
+
+  .xs\:focus\:ring-primary-vampire:focus {
+    --tw-ring-opacity: 1;
+    --tw-ring-color: rgba(181, 19, 19, var(--tw-ring-opacity));
+  }
+}

--- a/test/mock/demo-login-consent-server/templates/login.html
+++ b/test/mock/demo-login-consent-server/templates/login.html
@@ -5,99 +5,199 @@ SPDX-License-Identifier: Apache-2.0
  -->
 
 <html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <meta charset="utf-8">
-    <link rel="icon" type="images/x-icon" href="img/logo.png" >
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <meta charset="utf-8" />
+    <link rel="icon" type="images/x-icon" href="img/logo.png" />
     <title>Login Page</title>
-    <meta name="description" content="">
-    <meta name="keywords" content="">
-    <meta name="author" content="">
+    <meta name="description" content="" />
+    <meta name="keywords" content="" />
+    <meta name="author" content="" />
 
-    <link rel="stylesheet" href="https://unpkg.com/tailwindcss/dist/tailwind.min.css">
+    <link href="css/tailwind.css" rel="stylesheet" />
 
-    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700"
+      rel="stylesheet"
+    />
 
     <style>
-        .gradient {
-            background:linear-gradient(-180deg, #8631a0 0%, #360b4c 100%);
-        }
-        .inputColor{
-            background-color: #eeeaee
-        }
+      .gradient {
+        background: linear-gradient(-180deg, #8631a0 0%, #360b4c 100%);
+      }
+      .inputColor {
+        background-color: #eeeaee;
+      }
     </style>
+  </head>
 
-</head>
+  <body
+    onload="setRandomEmail();"
+    class="leading-normal tracking-normal"
+    style="background-color: #f4f1f5"
+  >
+    <section class="py-48">
+      <p class="text-neutrals-black text-2xl text-center font-bold">
+        Demo Sign In
+      </p>
+      <div class="container mx-auto h-auto lg:w-1/3 w-full">
+        <div class="mt-auto rounded-b rounded-t-none overflow-hidden">
+          <div class="p-14">
+            <form
+              class="
+                flex flex-col
+                bg-neutrals-white
+                shadow-xl
+                rounded-xl
+                lg:px-11
+                sm:px-11
+                px-4
+                pt-8
+                md:flex-wrap md:justify-between
+                h-auto
+              "
+              id="login_form"
+              method="post"
+            >
+              <input
+                type="hidden"
+                name="challenge"
+                value="{{.login_challenge}}"
+              />
 
-<body onload="setRandomEmail();" class="leading-normal tracking-normal text-white" style="background-color: #f4f1f5;">
-<section class="py-48">
-    <p class="text-black text-2xl text-center font-bold">Demo Sign In</p>
-    <div class="container mx-auto h-auto lg:w-1/3 w-full">
-            <div class="mt-auto rounded-b rounded-t-none overflow-hidden">
-                <div class="p-14">
-                    <form class="flex flex-col bg-white shadow-xl rounded-xl lg:px-11 sm:px-11 px-4 pt-8
-                    md:flex-wrap md:justify-between h-auto" id="login_form" method="post">
-                        <input type="hidden" name="challenge" value="{{.login_challenge}}">
+              <div
+                class="
+                  mb-4
+                  py-2
+                  px-4
+                  rounded-t-lg
+                  inputColor
+                  border-b-2 border-neutrals-mountainMist-dark
+                  lg:text-sm
+                  text-xs
+                "
+              >
+                <label
+                  class="block text-neutrals-dark font-bold mb-2 text-left"
+                  for="email"
+                >
+                  Email
+                </label>
+                <input
+                  class="
+                    w-full
+                    text-neutrals-dark
+                    leading-tight
+                    inputColor
+                    focus:outline-none
+                  "
+                  type="email"
+                  name="email"
+                  id="email"
+                  value="john.smith@example.com"
+                  required
+                />
+              </div>
 
-                        <div class="mb-4 py-2 px-4 rounded-t-lg inputColor border-b-2 border-gray-500 lg:text-sm text-xs">
-                            <label class="block text-gray-700 font-bold mb-2 text-left" for="email">
-                                Email
-                            </label>
-                            <input class="w-full text-gray-700 leading-tight inputColor
-                        focus:outline-none" type='email' name='email' id="email" value="john.smith@example.com" required>
-                        </div>
-
-                        <div class="mb-4 py-2 px-4 rounded-t-lg inputColor border-b-2 border-gray-500 lg:text-sm text-xs">
-                            <label class="block text-gray-700 font-bold mb-2 text-left" for="password">
-                                Password
-                            </label>
-                            <input class="w-full text-gray-700 leading-tight inputColor focus:outline-none"
-                    id="password" name='password' type="password" value="f00B@r!23">
-                        </div>
-                        <div class="flex items-center justify-center">
-                            <button class="flex items-center justify-center gradient rounded-md mb-8 h-10 px-8 shadow-lg"
-                                    type='submit'
-                                    id="accept" onclick="signIn()">
-                                <span class="flex-0" id="btn_text">Sign in</span>
-                                <svg
-                                        class="absolute animate-spin hidden"
-                                        width="24"
-                                        height="24"
-                                        id="spinner"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                >
-                                    <g transform="translate(2 2)" stroke="#FFF" stroke-width="3" fill="none" fill-rule="evenodd">
-                                        <circle opacity=".3" cx="10" cy="10" r="10" />
-                                        <path d="M20 10c0-5.523-4.477-10-10-10" stroke-linecap="round" stroke-linejoin="round" />
-                                    </g>
-                                </svg>
-                            </button>
-                        </div>
-                    </form>
-                </div>
+              <div
+                class="
+                  mb-4
+                  py-2
+                  px-4
+                  rounded-t-lg
+                  inputColor
+                  border-b-2 border-neutrals-mountainMist-dark
+                  lg:text-sm
+                  text-xs
+                "
+              >
+                <label
+                  class="block text-neutrals-dark font-bold mb-2 text-left"
+                  for="password"
+                >
+                  Password
+                </label>
+                <input
+                  class="
+                    w-full
+                    text-neutrals-dark
+                    leading-tight
+                    inputColor
+                    focus:outline-none
+                  "
+                  id="password"
+                  name="password"
+                  type="password"
+                  value="f00B@r!23"
+                />
+              </div>
+              <div class="flex items-center justify-center">
+                <button
+                  class="
+                    flex
+                    items-center
+                    justify-center
+                    gradient
+                    rounded-md
+                    mb-8
+                    h-10
+                    px-8
+                    shadow-lg
+                  "
+                  type="submit"
+                  id="accept"
+                  onclick="signIn()"
+                >
+                  <span class="flex-0 text-neutrals-white" id="btn_text"
+                    >Sign in</span
+                  >
+                  <svg
+                    class="absolute animate-spin hidden"
+                    width="24"
+                    height="24"
+                    id="spinner"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      transform="translate(2 2)"
+                      stroke="#FFF"
+                      stroke-width="3"
+                      fill="none"
+                      fill-rule="evenodd"
+                    >
+                      <circle opacity=".3" cx="10" cy="10" r="10" />
+                      <path
+                        d="M20 10c0-5.523-4.477-10-10-10"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </g>
+                  </svg>
+                </button>
+              </div>
+            </form>
+          </div>
         </div>
-    </div>
-</section>
-<script src="https://randojs.com/1.0.0.js"></script>
-<script type="application/javascript">
-    var randomemailprefix = "john.smith";
-    var randomemailsuffix = "@example.com";
-    var randomnumber = rando(1000000, 100000000);
+      </div>
+    </section>
+    <script src="https://randojs.com/1.0.0.js"></script>
+    <script type="application/javascript">
+      var randomemailprefix = "john.smith";
+      var randomemailsuffix = "@example.com";
+      var randomnumber = rando(1000000, 100000000);
 
-    function setRandomEmail() {
-        document.getElementById("email").value = randomemailprefix + randomnumber + randomemailsuffix;
-    }
+      function setRandomEmail() {
+        document.getElementById("email").value =
+          randomemailprefix + randomnumber + randomemailsuffix;
+      }
 
-    function signIn() {
-        document.getElementById("btn_text").style.visibility = 'hidden';
-        document.getElementById("spinner").style.display = 'block';
-        document.getElementById("login_form").action = '/login';
-    }
-</script>
-</body>
-
+      function signIn() {
+        document.getElementById("btn_text").style.visibility = "hidden";
+        document.getElementById("spinner").style.display = "block";
+        document.getElementById("login_form").action = "/login";
+      }
+    </script>
+  </body>
 </html>
-

--- a/test/mock/demo-login-consent-server/templates/uploadCred.html
+++ b/test/mock/demo-login-consent-server/templates/uploadCred.html
@@ -5,176 +5,368 @@ SPDX-License-Identifier: Apache-2.0
  -->
 
 <html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <meta charset="utf-8">
-    <link rel="icon" type="images/x-icon" href="img/logo.png" >
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <meta charset="utf-8" />
+    <link rel="icon" type="images/x-icon" href="img/logo.png" />
     <title>Upload Credential</title>
-    <meta name="description" content="">
-    <meta name="keywords" content="">
-    <meta name="author" content="">
+    <meta name="description" content="" />
+    <meta name="keywords" content="" />
+    <meta name="author" content="" />
 
-    <link rel="stylesheet" href="https://unpkg.com/tailwindcss/dist/tailwind.min.css">
-    <!--Replace with your tailwind.css once created-->
+    <link
+      href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css"
+      rel="stylesheet"
+    />
 
-    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link
+      href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
+    />
 
     <style>
-        .gradient {
-            background: linear-gradient(90deg, #000046 20%, #000046 100%);
-        }
+      .gradient {
+        background: linear-gradient(90deg, #000046 20%, #000046 100%);
+      }
     </style>
+  </head>
 
-</head>
-
-<body class="leading-normal tracking-normal text-white gradient" style="font-family: 'Source Sans Pro', sans-serif;">
-
-<!--Nav-->
-<nav id="header" class="fixed w-full z-30 top-0 text-white">
-
-    <div class="w-full container mx-auto flex flex-wrap items-center justify-between mt-0 py-2">
-
+  <body
+    class="leading-normal tracking-normal text-white gradient"
+    style="font-family: 'Source Sans Pro', sans-serif"
+  >
+    <!--Nav-->
+    <nav id="header" class="fixed w-full z-30 top-0 text-white">
+      <div
+        class="
+          w-full
+          container
+          mx-auto
+          flex flex-wrap
+          items-center
+          justify-between
+          mt-0
+          py-2
+        "
+      >
         <div class="pl-4 flex items-center">
-            <a class="toggleColour text-white no-underline hover:no-underline font-bold text-2xl lg:text-4xl"  href="javascript:history.back()">
-                <i class="fa fa-cubes" style="font-size:32px;color:white"></i>
-                TrustBloc Issuer
-            </a>
+          <a
+            class="
+              toggleColour
+              text-white
+              no-underline
+              hover:no-underline
+              font-bold
+              text-2xl
+              lg:text-4xl
+            "
+            href="javascript:history.back()"
+          >
+            <i class="fa fa-cubes" style="font-size: 32px; color: white"></i>
+            TrustBloc Issuer
+          </a>
         </div>
 
         <div class="block lg:hidden pr-4">
-            <button id="nav-toggle" class="flex items-center p-1 text-orange-800 hover:text-gray-900">
-                <svg class="fill-current h-6 w-6" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><title>Menu</title><path d="M0 3h20v2H0V3zm0 6h20v2H0V9zm0 6h20v2H0v-2z"/></svg>
-            </button>
+          <button
+            id="nav-toggle"
+            class="flex items-center p-1 text-orange-800 hover:text-gray-900"
+          >
+            <svg
+              class="fill-current h-6 w-6"
+              viewBox="0 0 20 20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>Menu</title>
+              <path d="M0 3h20v2H0V3zm0 6h20v2H0V9zm0 6h20v2H0v-2z" />
+            </svg>
+          </button>
         </div>
 
-        <div class="w-full flex-grow lg:flex lg:items-center lg:w-auto hidden lg:block mt-2 lg:mt-0 bg-white lg:bg-transparent text-black p-4 lg:p-0 z-20" id="nav-content">
-            <ul class="list-reset lg:flex justify-end flex-1 items-center">
-                <li class="mr-3">
-                    <a class="inline-block text-gray-400 no-underline hover:text-green hover:text-underline py-2 px-4" href="https://github.com/trustbloc/edge-sandbox">
-                        <i class="fa fa-github"></i></a>
-                </li>
-            </ul>
+        <div
+          class="
+            w-full
+            flex-grow
+            lg:flex lg:items-center lg:w-auto
+            hidden
+            lg:block
+            mt-2
+            lg:mt-0
+            bg-white
+            lg:bg-transparent
+            text-black
+            p-4
+            lg:p-0
+            z-20
+          "
+          id="nav-content"
+        >
+          <ul class="list-reset lg:flex justify-end flex-1 items-center">
+            <li class="mr-3">
+              <a
+                class="
+                  inline-block
+                  text-gray-400
+                  no-underline
+                  hover:text-green hover:text-underline
+                  py-2
+                  px-4
+                "
+                href="https://github.com/trustbloc/edge-sandbox"
+              >
+                <i class="fa fa-github"></i
+              ></a>
+            </li>
+          </ul>
         </div>
-    </div>
-    <hr class="border-b border-gray-100 opacity-25 my-0 py-0" />
-</nav>
+      </div>
+      <hr class="border-b border-gray-100 opacity-25 my-0 py-0" />
+    </nav>
 
-
-<div class="pt-12">
-
-    <div class="container px-3 mx-auto flex flex-wrap flex-col md:flex-row items-center">
+    <div class="pt-12">
+      <div
+        class="
+          container
+          px-3
+          mx-auto
+          flex flex-wrap flex-col
+          md:flex-row
+          items-center
+        "
+      >
         <!--Left Col-->
-        <div class="flex flex-col w-full md:w-2/5 justify-center items-start text-center md:text-left">
-            <h1 class="my-4 text-5xl font-bold leading-tight"></h1>
+        <div
+          class="
+            flex flex-col
+            w-full
+            md:w-2/5
+            justify-center
+            items-start
+            text-center
+            md:text-left
+          "
+        >
+          <h1 class="my-4 text-5xl font-bold leading-tight"></h1>
         </div>
+      </div>
     </div>
-</div>
 
-
-<div class="relative -mt-12 lg:-mt-32">
-    <svg viewBox="0 0 1428 174" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <div class="relative -mt-12 lg:-mt-32">
+      <svg
+        viewBox="0 0 1428 174"
+        version="1.1"
+        xmlns="http://www.w3.org/2000/svg"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+      >
         <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-            <g transform="translate(-2.000000, 44.000000)" fill="#FFFFFF" fill-rule="nonzero">
-                <path d="M0,0 C90.7283404,0.927527913 147.912752,27.187927 291.910178,59.9119003 C387.908462,81.7278826 543.605069,89.334785 759,82.7326078 C469.336065,156.254352 216.336065,153.6679 0,74.9732496" opacity="0.100000001"></path>
-                <path d="M100,104.708498 C277.413333,72.2345949 426.147877,52.5246657 546.203633,45.5787101 C666.259389,38.6327546 810.524845,41.7979068 979,55.0741668 C931.069965,56.122511 810.303266,74.8455141 616.699903,111.243176 C423.096539,147.640838 250.863238,145.462612 100,104.708498 Z" opacity="0.100000001"></path>
-                <path d="M1046,51.6521276 C1130.83045,29.328812 1279.08318,17.607883 1439,40.1656806 L1439,120 C1271.17211,77.9435312 1140.17211,55.1609071 1046,51.6521276 Z" id="Path-4" opacity="0.200000003"></path>
-            </g>
-            <g transform="translate(-4.000000, 76.000000)" fill="#FFFFFF" fill-rule="nonzero">
-                <path d="M0.457,34.035 C57.086,53.198 98.208,65.809 123.822,71.865 C181.454,85.495 234.295,90.29 272.033,93.459 C311.355,96.759 396.635,95.801 461.025,91.663 C486.76,90.01 518.727,86.372 556.926,80.752 C595.747,74.596 622.372,70.008 636.799,66.991 C663.913,61.324 712.501,49.503 727.605,46.128 C780.47,34.317 818.839,22.532 856.324,15.904 C922.689,4.169 955.676,2.522 1011.185,0.432 C1060.705,1.477 1097.39,3.129 1121.236,5.387 C1161.703,9.219 1208.621,17.821 1235.4,22.304 C1285.855,30.748 1354.351,47.432 1440.886,72.354 L1441.191,104.352 L1.121,104.031 L0.457,34.035 Z"></path>
-            </g>
+          <g
+            transform="translate(-2.000000, 44.000000)"
+            fill="#FFFFFF"
+            fill-rule="nonzero"
+          >
+            <path
+              d="M0,0 C90.7283404,0.927527913 147.912752,27.187927 291.910178,59.9119003 C387.908462,81.7278826 543.605069,89.334785 759,82.7326078 C469.336065,156.254352 216.336065,153.6679 0,74.9732496"
+              opacity="0.100000001"
+            ></path>
+            <path
+              d="M100,104.708498 C277.413333,72.2345949 426.147877,52.5246657 546.203633,45.5787101 C666.259389,38.6327546 810.524845,41.7979068 979,55.0741668 C931.069965,56.122511 810.303266,74.8455141 616.699903,111.243176 C423.096539,147.640838 250.863238,145.462612 100,104.708498 Z"
+              opacity="0.100000001"
+            ></path>
+            <path
+              d="M1046,51.6521276 C1130.83045,29.328812 1279.08318,17.607883 1439,40.1656806 L1439,120 C1271.17211,77.9435312 1140.17211,55.1609071 1046,51.6521276 Z"
+              id="Path-4"
+              opacity="0.200000003"
+            ></path>
+          </g>
+          <g
+            transform="translate(-4.000000, 76.000000)"
+            fill="#FFFFFF"
+            fill-rule="nonzero"
+          >
+            <path
+              d="M0.457,34.035 C57.086,53.198 98.208,65.809 123.822,71.865 C181.454,85.495 234.295,90.29 272.033,93.459 C311.355,96.759 396.635,95.801 461.025,91.663 C486.76,90.01 518.727,86.372 556.926,80.752 C595.747,74.596 622.372,70.008 636.799,66.991 C663.913,61.324 712.501,49.503 727.605,46.128 C780.47,34.317 818.839,22.532 856.324,15.904 C922.689,4.169 955.676,2.522 1011.185,0.432 C1060.705,1.477 1097.39,3.129 1121.236,5.387 C1161.703,9.219 1208.621,17.821 1235.4,22.304 C1285.855,30.748 1354.351,47.432 1440.886,72.354 L1441.191,104.352 L1.121,104.031 L0.457,34.035 Z"
+            ></path>
+          </g>
         </g>
-    </svg>
-</div>
-
-
-<section class="bg-white border-b py-24">
-    <div class="container mx-auto flex  flex-wrap pt-4 pb-12">
-        <div class="w-full md:w-1/3 p-6 flex flex-col flex-grow flex-shrink">
-            <div class="flex-none mt-auto bg-white rounded-b rounded-t-none overflow-hidden p-6">
-                <div class="flex items-center justify-center">
-                    <form class="bg-white shadow-md rounded px-32 pt-8 pb-8 md:flex-wrap md:justify-between" action="/login" method="post">
-                        <input type="hidden" name="challenge" value="{{.login_challenge}}">
-
-                        <div class="mb-4 hidden">
-                            <label class="block text-gray-700 text-sm font-bold mb-2 text-left" for="email">
-                                Email
-                            </label>
-                            <input class="shadow appearance-none border rounded w-full py-2 px-8 text-gray-700
-                        leading-tight focus:outline-none focus:ring" type='email' name='email' id='email' id="email" value="john.smith@example.com" required>
-                        </div>
-
-                        <div class="mb-6 hidden">
-                            <label class="block text-gray-700 text-sm font-bold mb-2 text-left" for="password">
-                                Password
-                            </label>
-                            <input class="shadow appearance-none border rounded w-full py-2 px-8 text-gray-700 mb-3 leading-tight
-                        focus:outline-none focus:ring" id="password" name='password' type="password" value="f00B@r!23">
-                            <p class="text-green-500 text-xs italic text-left">For demo password is optional.</p>
-                        </div>
-
-                        <div class="flex items-center justify-center">
-                            <button class="mx-auto lg:mx-0 hover:underline gradient text-white font-bold rounded-full my-4 py-2 px-8 shadow-lg" type='submit' id="accept" name='btn_login'>
-                                Scan your Driving license
-                            </button>
-                        </div>
-                    </form>
-                </div>
-            </div>
-        </div>
-
+      </svg>
     </div>
-</section>
 
-<footer>
-    <section class="container mx-auto text-center py-6 mb-12">
-        <div class="text-lg text-white font py-1">
-            Copyright &copy; <a href="https://securekey.com/" rel="nofollow">SecureKey Technologies</a> and the TrustBloc Contributors.
+    <section class="bg-white border-b py-24">
+      <div class="container mx-auto flex flex-wrap pt-4 pb-12">
+        <div class="w-full md:w-1/3 p-6 flex flex-col flex-grow flex-shrink">
+          <div
+            class="
+              flex-none
+              mt-auto
+              bg-white
+              rounded-b rounded-t-none
+              overflow-hidden
+              p-6
+            "
+          >
+            <div class="flex items-center justify-center">
+              <form
+                class="
+                  bg-white
+                  shadow-md
+                  rounded
+                  px-32
+                  pt-8
+                  pb-8
+                  md:flex-wrap md:justify-between
+                "
+                action="/login"
+                method="post"
+              >
+                <input
+                  type="hidden"
+                  name="challenge"
+                  value="{{.login_challenge}}"
+                />
+
+                <div class="mb-4 hidden">
+                  <label
+                    class="block text-gray-700 text-sm font-bold mb-2 text-left"
+                    for="email"
+                  >
+                    Email
+                  </label>
+                  <input
+                    class="
+                      shadow
+                      appearance-none
+                      border
+                      rounded
+                      w-full
+                      py-2
+                      px-8
+                      text-gray-700
+                      leading-tight
+                      focus:outline-none focus:ring
+                    "
+                    type="email"
+                    name="email"
+                    id="email"
+                    id="email"
+                    value="john.smith@example.com"
+                    required
+                  />
+                </div>
+
+                <div class="mb-6 hidden">
+                  <label
+                    class="block text-gray-700 text-sm font-bold mb-2 text-left"
+                    for="password"
+                  >
+                    Password
+                  </label>
+                  <input
+                    class="
+                      shadow
+                      appearance-none
+                      border
+                      rounded
+                      w-full
+                      py-2
+                      px-8
+                      text-gray-700
+                      mb-3
+                      leading-tight
+                      focus:outline-none focus:ring
+                    "
+                    id="password"
+                    name="password"
+                    type="password"
+                    value="f00B@r!23"
+                  />
+                  <p class="text-green-500 text-xs italic text-left">
+                    For demo password is optional.
+                  </p>
+                </div>
+
+                <div class="flex items-center justify-center">
+                  <button
+                    class="
+                      mx-auto
+                      lg:mx-0
+                      hover:underline
+                      gradient
+                      text-white
+                      font-bold
+                      rounded-full
+                      my-4
+                      py-2
+                      px-8
+                      shadow-lg
+                    "
+                    type="submit"
+                    id="accept"
+                    name="btn_login"
+                  >
+                    Scan your Driving license
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
         </div>
+      </div>
     </section>
-</footer>
 
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <footer>
+      <section class="container mx-auto text-center py-6 mb-12">
+        <div class="text-lg text-white font py-1">
+          Copyright &copy;
+          <a href="https://securekey.com/" rel="nofollow"
+            >SecureKey Technologies</a
+          >
+          and the TrustBloc Contributors.
+        </div>
+      </section>
+    </footer>
 
-<script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 
-    var navMenuDiv = document.getElementById("nav-content");
-    var navMenu = document.getElementById("nav-toggle");
+    <script>
+      var navMenuDiv = document.getElementById("nav-content");
+      var navMenu = document.getElementById("nav-toggle");
 
-    document.onclick = check;
-    function check(e){
+      document.onclick = check;
+      function check(e) {
         var target = (e && e.target) || (event && event.srcElement);
 
         //Nav Menu
         if (!checkParent(target, navMenuDiv)) {
-            // click NOT on the menu
-            if (checkParent(target, navMenu)) {
-                // click on the link
-                if (navMenuDiv.classList.contains("hidden")) {
-                    navMenuDiv.classList.remove("hidden");
-                } else {navMenuDiv.classList.add("hidden");}
+          // click NOT on the menu
+          if (checkParent(target, navMenu)) {
+            // click on the link
+            if (navMenuDiv.classList.contains("hidden")) {
+              navMenuDiv.classList.remove("hidden");
             } else {
-                // click both outside link and outside menu, hide menu
-                navMenuDiv.classList.add("hidden");
+              navMenuDiv.classList.add("hidden");
             }
+          } else {
+            // click both outside link and outside menu, hide menu
+            navMenuDiv.classList.add("hidden");
+          }
         }
-    }
+      }
 
-    function checkParent(t, elm) {
-        while(t.parentNode) {
-            if( t == elm ) {return true;}
-            t = t.parentNode;
+      function checkParent(t, elm) {
+        while (t.parentNode) {
+          if (t == elm) {
+            return true;
+          }
+          t = t.parentNode;
         }
         return false;
-    }
-
-</script>
-
-
-</body>
-
+      }
+    </script>
+  </body>
 </html>
-

--- a/test/mock/demo-login-consent-server/templates/uploadCredConsent.html
+++ b/test/mock/demo-login-consent-server/templates/uploadCredConsent.html
@@ -5,195 +5,379 @@ SPDX-License-Identifier: Apache-2.0
  -->
 
 <html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <meta charset="utf-8">
-    <link rel="icon" type="images/x-icon" href="img/logo.png" >
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <meta charset="utf-8" />
+    <link rel="icon" type="images/x-icon" href="img/logo.png" />
     <title>Consent Page</title>
-    <meta name="description" content="">
-    <meta name="keywords" content="">
-    <meta name="author" content="">
+    <meta name="description" content="" />
+    <meta name="keywords" content="" />
+    <meta name="author" content="" />
 
-    <link rel="stylesheet" href="https://unpkg.com/tailwindcss/dist/tailwind.min.css">
-    <!--Replace with your tailwind.css once created-->
+    <link
+      href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css"
+      rel="stylesheet"
+    />
 
-    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link
+      href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
+    />
 
     <style>
-        .gradient {
-            background: linear-gradient(90deg, #000046 20%, #000046 100%);
-        }
+      .gradient {
+        background: linear-gradient(90deg, #000046 20%, #000046 100%);
+      }
     </style>
+  </head>
 
-</head>
-
-<body class="leading-normal tracking-normal text-white gradient" style="font-family: 'Source Sans Pro', sans-serif;">
-
-<!--Nav-->
-<nav id="header" class="fixed w-full z-30 top-0 text-white">
-
-    <div class="w-full container mx-auto flex flex-wrap items-center justify-between mt-0 py-2">
-
+  <body
+    class="leading-normal tracking-normal text-white gradient"
+    style="font-family: 'Source Sans Pro', sans-serif"
+  >
+    <!--Nav-->
+    <nav id="header" class="fixed w-full z-30 top-0 text-white">
+      <div
+        class="
+          w-full
+          container
+          mx-auto
+          flex flex-wrap
+          items-center
+          justify-between
+          mt-0
+          py-2
+        "
+      >
         <div class="pl-4 flex items-center">
-            <a class="toggleColour text-white no-underline hover:no-underline font-bold text-2xl lg:text-4xl"  href="javascript:history.back()">
-                <i class="fa fa-cubes" style="font-size:32px;color:white"></i>
-                TrustBloc Issuer
-            </a>
+          <a
+            class="
+              toggleColour
+              text-white
+              no-underline
+              hover:no-underline
+              font-bold
+              text-2xl
+              lg:text-4xl
+            "
+            href="javascript:history.back()"
+          >
+            <i class="fa fa-cubes" style="font-size: 32px; color: white"></i>
+            TrustBloc Issuer
+          </a>
         </div>
 
         <div class="block lg:hidden pr-4">
-            <button id="nav-toggle" class="flex items-center p-1 text-orange-800 hover:text-gray-900">
-                <svg class="fill-current h-6 w-6" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><title>Menu</title><path d="M0 3h20v2H0V3zm0 6h20v2H0V9zm0 6h20v2H0v-2z"/></svg>
-            </button>
+          <button
+            id="nav-toggle"
+            class="flex items-center p-1 text-orange-800 hover:text-gray-900"
+          >
+            <svg
+              class="fill-current h-6 w-6"
+              viewBox="0 0 20 20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>Menu</title>
+              <path d="M0 3h20v2H0V3zm0 6h20v2H0V9zm0 6h20v2H0v-2z" />
+            </svg>
+          </button>
         </div>
 
-        <div class="w-full flex-grow lg:flex lg:items-center lg:w-auto hidden lg:block mt-2 lg:mt-0 bg-white lg:bg-transparent text-black p-4 lg:p-0 z-20" id="nav-content">
-            <ul class="list-reset lg:flex justify-end flex-1 items-center">
-                <li class="mr-3">
-                    <a class="inline-block text-gray-400 no-underline hover:text-green hover:text-underline py-2 px-4" href="https://github.com/trustbloc/edge-sandbox"><i class="fa fa-github"></i></a>
-                </li>
-            </ul>
+        <div
+          class="
+            w-full
+            flex-grow
+            lg:flex lg:items-center lg:w-auto
+            hidden
+            lg:block
+            mt-2
+            lg:mt-0
+            bg-white
+            lg:bg-transparent
+            text-black
+            p-4
+            lg:p-0
+            z-20
+          "
+          id="nav-content"
+        >
+          <ul class="list-reset lg:flex justify-end flex-1 items-center">
+            <li class="mr-3">
+              <a
+                class="
+                  inline-block
+                  text-gray-400
+                  no-underline
+                  hover:text-green hover:text-underline
+                  py-2
+                  px-4
+                "
+                href="https://github.com/trustbloc/edge-sandbox"
+                ><i class="fa fa-github"></i
+              ></a>
+            </li>
+          </ul>
         </div>
-    </div>
-    <hr class="border-b border-gray-100 opacity-25 my-0 py-0" />
-</nav>
+      </div>
+      <hr class="border-b border-gray-100 opacity-25 my-0 py-0" />
+    </nav>
 
-
-<div class="pt-12">
-
-    <div class="container px-3 mx-auto flex flex-wrap flex-col md:flex-row items-center">
+    <div class="pt-12">
+      <div
+        class="
+          container
+          px-3
+          mx-auto
+          flex flex-wrap flex-col
+          md:flex-row
+          items-center
+        "
+      >
         <!--Left Col-->
-        <div class="flex flex-col w-full md:w-2/5 justify-center items-start text-center md:text-left">
-            <h1 class="my-4 text-5xl font-bold leading-tight"></h1>
+        <div
+          class="
+            flex flex-col
+            w-full
+            md:w-2/5
+            justify-center
+            items-start
+            text-center
+            md:text-left
+          "
+        >
+          <h1 class="my-4 text-5xl font-bold leading-tight"></h1>
         </div>
+      </div>
     </div>
-</div>
 
-
-<div class="relative -mt-12 lg:-mt-32">
-    <svg viewBox="0 0 1428 174" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <div class="relative -mt-12 lg:-mt-32">
+      <svg
+        viewBox="0 0 1428 174"
+        version="1.1"
+        xmlns="http://www.w3.org/2000/svg"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+      >
         <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-            <g transform="translate(-2.000000, 44.000000)" fill="#FFFFFF" fill-rule="nonzero">
-                <path d="M0,0 C90.7283404,0.927527913 147.912752,27.187927 291.910178,59.9119003 C387.908462,81.7278826 543.605069,89.334785 759,82.7326078 C469.336065,156.254352 216.336065,153.6679 0,74.9732496" opacity="0.100000001"></path>
-                <path d="M100,104.708498 C277.413333,72.2345949 426.147877,52.5246657 546.203633,45.5787101 C666.259389,38.6327546 810.524845,41.7979068 979,55.0741668 C931.069965,56.122511 810.303266,74.8455141 616.699903,111.243176 C423.096539,147.640838 250.863238,145.462612 100,104.708498 Z" opacity="0.100000001"></path>
-                <path d="M1046,51.6521276 C1130.83045,29.328812 1279.08318,17.607883 1439,40.1656806 L1439,120 C1271.17211,77.9435312 1140.17211,55.1609071 1046,51.6521276 Z" id="Path-4" opacity="0.200000003"></path>
-            </g>
-            <g transform="translate(-4.000000, 76.000000)" fill="#FFFFFF" fill-rule="nonzero">
-                <path d="M0.457,34.035 C57.086,53.198 98.208,65.809 123.822,71.865 C181.454,85.495 234.295,90.29 272.033,93.459 C311.355,96.759 396.635,95.801 461.025,91.663 C486.76,90.01 518.727,86.372 556.926,80.752 C595.747,74.596 622.372,70.008 636.799,66.991 C663.913,61.324 712.501,49.503 727.605,46.128 C780.47,34.317 818.839,22.532 856.324,15.904 C922.689,4.169 955.676,2.522 1011.185,0.432 C1060.705,1.477 1097.39,3.129 1121.236,5.387 C1161.703,9.219 1208.621,17.821 1235.4,22.304 C1285.855,30.748 1354.351,47.432 1440.886,72.354 L1441.191,104.352 L1.121,104.031 L0.457,34.035 Z"></path>
-            </g>
+          <g
+            transform="translate(-2.000000, 44.000000)"
+            fill="#FFFFFF"
+            fill-rule="nonzero"
+          >
+            <path
+              d="M0,0 C90.7283404,0.927527913 147.912752,27.187927 291.910178,59.9119003 C387.908462,81.7278826 543.605069,89.334785 759,82.7326078 C469.336065,156.254352 216.336065,153.6679 0,74.9732496"
+              opacity="0.100000001"
+            ></path>
+            <path
+              d="M100,104.708498 C277.413333,72.2345949 426.147877,52.5246657 546.203633,45.5787101 C666.259389,38.6327546 810.524845,41.7979068 979,55.0741668 C931.069965,56.122511 810.303266,74.8455141 616.699903,111.243176 C423.096539,147.640838 250.863238,145.462612 100,104.708498 Z"
+              opacity="0.100000001"
+            ></path>
+            <path
+              d="M1046,51.6521276 C1130.83045,29.328812 1279.08318,17.607883 1439,40.1656806 L1439,120 C1271.17211,77.9435312 1140.17211,55.1609071 1046,51.6521276 Z"
+              id="Path-4"
+              opacity="0.200000003"
+            ></path>
+          </g>
+          <g
+            transform="translate(-4.000000, 76.000000)"
+            fill="#FFFFFF"
+            fill-rule="nonzero"
+          >
+            <path
+              d="M0.457,34.035 C57.086,53.198 98.208,65.809 123.822,71.865 C181.454,85.495 234.295,90.29 272.033,93.459 C311.355,96.759 396.635,95.801 461.025,91.663 C486.76,90.01 518.727,86.372 556.926,80.752 C595.747,74.596 622.372,70.008 636.799,66.991 C663.913,61.324 712.501,49.503 727.605,46.128 C780.47,34.317 818.839,22.532 856.324,15.904 C922.689,4.169 955.676,2.522 1011.185,0.432 C1060.705,1.477 1097.39,3.129 1121.236,5.387 C1161.703,9.219 1208.621,17.821 1235.4,22.304 C1285.855,30.748 1354.351,47.432 1440.886,72.354 L1441.191,104.352 L1.121,104.031 L0.457,34.035 Z"
+            ></path>
+          </g>
         </g>
-    </svg>
-</div>
-
-
-<section class="bg-white border-b py-24">
-    <div class="container mx-auto flex  flex-wrap pt-4 pb-12">
-        <div class="w-full md:w-1/3 p-6 flex flex-col flex-grow flex-shrink">
-            <div class="flex-none mt-auto bg-white rounded-b rounded-t-none overflow-hidden p-6">
-                <div class="flex items-center justify-center">
-                    <div class="max-w-3xl rounded shadow-lg">
-                        <img class="object-scale-down h-48 w-full" src="img/consent.png">
-                        <div class="px-6 py-4 bg-gray-100 justify-center">
-                            <p class="font-bold text-xl text-black mb-2">An application requests access to your data</p>
-                            <form action="" method="POST">
-                                <p class="text-gray-700 text-base"><strong>{{.ClientID}}</strong> wants access resources on your behalf:</p>
-                                {{range $element := .Scope}}
-                                <label class="md:w-2/3 block text-gray-500 font-bold">
-                                    <input class="mr-2 leading-tight filled-in" type="checkbox" id="{{$element}}" value="{{$element}}" name="grant_scope" checked="checked" />
-                                    <span class="text-lg text-black" id="scopeName" for="{{$element}}">{{$element}}</span>
-                                    {{end}}
-                                </label>
-                                <br>
-                                <p>
-                                    <input type="hidden" name="challenge" value="{{.Challenge}}">
-                                <div class="grid grid-cols-2 gap-8">
-                                    <div>
-                                        <button type="submit" name="submit" id="reject" class="col-start-1 col-end-2 bg-transparent hover:bg-red-700 text-black font-semibold hover:text-white px-4 py-2 m-2 border border-red-500 hover:border-transparent rounded"      value="reject" >Deny</button>
-                                    </div>
-                                    <div class="flex justify-end">
-                                        <button type="submit" name="submit" id="accept" class="col-end-2 col-span-2 bg-transparent hover:bg-green-400 text-green-700 font-semibold hover:text-white px-4 py-2 m-2 border border-green-500 hover:border-transparent rounded"  value="accept" >Agree</button>
-                                    </div>
-                                </div>
-                                </p>
-                            </form>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-
+      </svg>
     </div>
-</section>
 
-<footer>
-    <section class="container mx-auto text-center py-6 mb-12">
-        <div class="text-lg text-white font py-1">
-            Copyright &copy; <a href="https://securekey.com/" rel="nofollow">SecureKey Technologies</a> and the TrustBloc Contributors.
+    <section class="bg-white border-b py-24">
+      <div class="container mx-auto flex flex-wrap pt-4 pb-12">
+        <div class="w-full md:w-1/3 p-6 flex flex-col flex-grow flex-shrink">
+          <div
+            class="
+              flex-none
+              mt-auto
+              bg-white
+              rounded-b rounded-t-none
+              overflow-hidden
+              p-6
+            "
+          >
+            <div class="flex items-center justify-center">
+              <div class="max-w-3xl rounded shadow-lg">
+                <img
+                  class="object-scale-down h-48 w-full"
+                  src="img/consent.png"
+                />
+                <div class="px-6 py-4 bg-gray-100 justify-center">
+                  <p class="font-bold text-xl text-black mb-2">
+                    An application requests access to your data
+                  </p>
+                  <form action="" method="POST">
+                    <p class="text-gray-700 text-base">
+                      <strong>{{.ClientID}}</strong> wants access resources on
+                      your behalf:
+                    </p>
+                    {{range $element := .Scope}}
+                    <label class="md:w-2/3 block text-gray-500 font-bold">
+                      <input
+                        class="mr-2 leading-tight filled-in"
+                        type="checkbox"
+                        id="{{$element}}"
+                        value="{{$element}}"
+                        name="grant_scope"
+                        checked="checked"
+                      />
+                      <span
+                        class="text-lg text-black"
+                        id="scopeName"
+                        for="{{$element}}"
+                        >{{$element}}</span
+                      >
+                      {{end}}
+                    </label>
+                    <br />
+
+                    <input
+                      type="hidden"
+                      name="challenge"
+                      value="{{.Challenge}}"
+                    />
+                    <div class="grid grid-cols-2 gap-8">
+                      <div>
+                        <button
+                          type="submit"
+                          name="submit"
+                          id="reject"
+                          class="
+                            col-start-1 col-end-2
+                            bg-transparent
+                            hover:bg-red-700
+                            text-black
+                            font-semibold
+                            hover:text-white
+                            px-4
+                            py-2
+                            m-2
+                            border border-red-500
+                            hover:border-transparent
+                            rounded
+                          "
+                          value="reject"
+                        >
+                          Deny
+                        </button>
+                      </div>
+                      <div class="flex justify-end">
+                        <button
+                          type="submit"
+                          name="submit"
+                          id="accept"
+                          class="
+                            col-end-2 col-span-2
+                            bg-transparent
+                            hover:bg-green-400
+                            text-green-700
+                            font-semibold
+                            hover:text-white
+                            px-4
+                            py-2
+                            m-2
+                            border border-green-500
+                            hover:border-transparent
+                            rounded
+                          "
+                          value="accept"
+                        >
+                          Agree
+                        </button>
+                      </div>
+                    </div>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
+      </div>
     </section>
-</footer>
 
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <footer>
+      <section class="container mx-auto text-center py-6 mb-12">
+        <div class="text-lg text-white font py-1">
+          Copyright &copy;
+          <a href="https://securekey.com/" rel="nofollow"
+            >SecureKey Technologies</a
+          >
+          and the TrustBloc Contributors.
+        </div>
+      </section>
+    </footer>
 
-<script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 
-    var navMenuDiv = document.getElementById("nav-content");
-    var navMenu = document.getElementById("nav-toggle");
+    <script>
+      var navMenuDiv = document.getElementById("nav-content");
+      var navMenu = document.getElementById("nav-toggle");
 
-    document.onclick = check;
-    function check(e){
+      document.onclick = check;
+      function check(e) {
         var target = (e && e.target) || (event && event.srcElement);
 
         //Nav Menu
         if (!checkParent(target, navMenuDiv)) {
-            // click NOT on the menu
-            if (checkParent(target, navMenu)) {
-                // click on the link
-                if (navMenuDiv.classList.contains("hidden")) {
-                    navMenuDiv.classList.remove("hidden");
-                } else {navMenuDiv.classList.add("hidden");}
+          // click NOT on the menu
+          if (checkParent(target, navMenu)) {
+            // click on the link
+            if (navMenuDiv.classList.contains("hidden")) {
+              navMenuDiv.classList.remove("hidden");
             } else {
-                // click both outside link and outside menu, hide menu
-                navMenuDiv.classList.add("hidden");
+              navMenuDiv.classList.add("hidden");
             }
+          } else {
+            // click both outside link and outside menu, hide menu
+            navMenuDiv.classList.add("hidden");
+          }
         }
-    }
+      }
 
-    function checkParent(t, elm) {
-        while(t.parentNode) {
-            if( t == elm ) {return true;}
-            t = t.parentNode;
+      function checkParent(t, elm) {
+        while (t.parentNode) {
+          if (t == elm) {
+            return true;
+          }
+          t = t.parentNode;
         }
         return false;
-    }
-
-</script>
-<script type="text/javascript">
-    // todo : Add friendly name for the scope issue-508
-    function getScopeName(name) {
+      }
+    </script>
+    <script type="text/javascript">
+      // todo : Add friendly name for the scope issue-508
+      function getScopeName(name) {
         var scopes = {
-            'mDL': 'Driving License',
-            'StudentCard': 'Student Card',
-            'TravelCard': 'Travel Card',
-            'UniversityDegreeCredential': 'University Degree',
-            'CertifiedMillTestReport': 'Credit Mill Test Report',
-            'CrudeProductCredential': 'Crude Product Credential',
-            'PermanentResidentCard': 'Permanent Resident Card',
-            'CreditCardStatement': 'Credit Card Statement',
-            'CreditScore': 'Credit Score Report',
+          mDL: "Driving License",
+          StudentCard: "Student Card",
+          TravelCard: "Travel Card",
+          UniversityDegreeCredential: "University Degree",
+          CertifiedMillTestReport: "Credit Mill Test Report",
+          CrudeProductCredential: "Crude Product Credential",
+          PermanentResidentCard: "Permanent Resident Card",
+          CreditCardStatement: "Credit Card Statement",
+          CreditScore: "Credit Score Report",
         };
         return scopes[name];
-    }
-    $(document).ready(function () {
-        var name = document.getElementById("scopeName").innerText
-        var scopeName =  getScopeName(name);
+      }
+      $(document).ready(function () {
+        var name = document.getElementById("scopeName").innerText;
+        var scopeName = getScopeName(name);
         document.getElementById("scopeName").innerText = scopeName;
-    });
-</script>
-</body>
-
+      });
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
Fixes #1312

Our demo login page now uses tailwindcss styles generated from our theme. Updating the rest of the demo pages would take sufficient amount of time, because they were not implemented with our theme and lots of colors that are currently in use there do not exist in our theme. Updated default tailwindcss imports for those pages instead.

<img width="812" alt="image" src="https://user-images.githubusercontent.com/33902374/145985803-8ef0f043-4c5d-4eb4-b3f9-c9fceafdb22d.png">

Signed-off-by: Anton Biriukov <anton.biriukov@securekey.com>