### PR TITLE
feat: added loading state, auto refresh to add and delete vault modals

### DIFF
--- a/cmd/wallet-web/src/components/InputField/InputField.vue
+++ b/cmd/wallet-web/src/components/InputField/InputField.vue
@@ -9,8 +9,9 @@
     <input
       :id="'input-' + label"
       v-bind="$attrs"
+      :name="name"
       :disabled="!characterCount"
-      @input="$emit('update', $event.target.value)"
+      @input="onInput"
       @keyup.enter="characterCount"
     />
     <label :for="'input-' + label" class="input-label">{{ label }}</label>
@@ -33,7 +34,7 @@ export default {
   props: {
     label: {
       type: String,
-      default: '',
+      required: true,
     },
     helperMessage: {
       type: String,
@@ -41,15 +42,23 @@ export default {
     },
     value: {
       type: String,
-      default: '',
+      required: true,
     },
   },
-  emits: ['update'],
+  emits: ['input'],
   computed: {
     characterCount() {
       return this.value
         ? this.value.length + '/' + this.$attrs['maxlength']
         : 0 + '/' + this.$attrs['maxlength'];
+    },
+    name() {
+      return this.label.toLowerCase();
+    },
+  },
+  methods: {
+    onInput: function (event) {
+      this.$emit('input', event.target.value);
     },
   },
 };

--- a/cmd/wallet-web/src/components/Vaults/AddVaultModal.vue
+++ b/cmd/wallet-web/src/components/Vaults/AddVaultModal.vue
@@ -7,7 +7,6 @@
 <template>
   <modal :show="showModal" :show-close-button="true">
     <template #content>
-      <!--content-->
       <div
         class="
           flex
@@ -32,11 +31,10 @@
           :value="vaultName"
           type="text"
           maxlength="42"
-          @update="receivedVaultName($event)"
+          @input="updateVaultName($event)"
         />
       </div>
     </template>
-    <!--button container-->
     <template #actionButton>
       <styled-button
         class="order-first md:order-last lg:order-last"
@@ -50,26 +48,28 @@
 </template>
 
 <script>
-import Modal from '@/components/Modal/Modal.vue';
-import InputField from '@/components/InputField/InputField';
+import { computed, ref, watch } from 'vue';
+import { useStore } from 'vuex';
 import { CollectionManager } from '@trustbloc/wallet-sdk';
-import { mapGetters } from 'vuex';
 import { useI18n } from 'vue-i18n';
 import { vaultsMutations } from '@/pages/Vaults.vue';
+import Modal from '@/components/Modal/Modal.vue';
+import InputField from '@/components/InputField/InputField';
 import StyledButton from '@/components/StyledButton/StyledButton';
-import { ref, watch } from 'vue/dist/vue.esm-bundler';
 
-const props = {
-  show: {
-    type: Boolean,
-    default: false,
-  },
-};
 export default {
   name: 'AddVault',
   components: { StyledButton, InputField, Modal },
-  props,
+  props: {
+    show: {
+      type: Boolean,
+      default: false,
+    },
+  },
   setup(props) {
+    const store = useStore();
+    const agentInstance = computed(() => store.getters['agent/getInstance']);
+    const currentUser = computed(() => store.getters.getCurrentUser);
     const { t } = useI18n();
     const showModal = ref(false);
     watch(
@@ -79,32 +79,28 @@ export default {
       }
     );
 
-    return {
-      t,
-      showModal,
-    };
+    return { agentInstance, currentUser, showModal, t };
   },
   data() {
     return {
       vaultName: '',
+      loading: false,
     };
   },
   methods: {
-    ...mapGetters('agent', { getAgentInstance: 'getInstance' }),
-    ...mapGetters(['getCurrentUser']),
-    receivedVaultName(data) {
-      this.vaultName = data;
+    updateVaultName(name) {
+      this.vaultName = name;
     },
     async addVault() {
-      // Integration with collections API.
-      const { user, token } = this.getCurrentUser().profile;
-      const collectionManager = new CollectionManager({ agent: this.getAgentInstance(), user });
-      const name = this.vaultName;
+      this.loading = true;
+      const { user, token } = this.currentUser.profile;
+      const collectionManager = new CollectionManager({ agent: this.agentInstance, user });
       try {
-        const id = await collectionManager.create(token, { name });
+        const id = await collectionManager.create(token, { name: this.vaultName });
         if (id) {
           vaultsMutations.setVaultsOutdated(true);
           this.showModal = false;
+          this.loading = false;
         }
         // TODO: add an error state to display in the UI
       } catch (e) {


### PR DESCRIPTION
Fixes #1309 

- [x] Added loading state from the styled button to the delete vault button 
- [x] Made modal wait till the delete operation completes and update all modals with the fix
- [x] Used existing reactive property from `pages/Vaults.vue` like [the following](https://github.com/trustbloc/wallet/blob/main/cmd/wallet-web/src/components/Vaults/AddVaultModal.vue#L146-L149) to auto-refresh list of vaults


https://user-images.githubusercontent.com/33902374/146252142-fb9e62e1-f94c-4fdb-b9c1-b117e7d1146c.mov

Signed-off-by: Anton Biriukov <anton.biriukov@securekey.com>