### PR TITLE
fix: Loading spinner is not centered in the authentication providers 

### DIFF
--- a/cmd/wallet-web/src/pages/Signin.vue
+++ b/cmd/wallet-web/src/pages/Signin.vue
@@ -49,7 +49,18 @@
             {{ t('Signin.heading') }}
           </span>
         </div>
-        <div class="grid grid-cols-1 gap-5 w-full sm:px-32 h-64 mb-12 items-center content-center">
+        <div
+          class="
+            grid grid-cols-1
+            gap-5
+            w-full
+            sm:px-32
+            h-64
+            mb-12
+            content-center
+            justify-items-center
+          "
+        >
           <Spinner v-if="loading" />
           <button
             v-for="(provider, index) in providers"
@@ -57,6 +68,7 @@
             :key="index"
             class="
               items-center
+              w-full
               h-11
               text-sm
               font-bold

--- a/cmd/wallet-web/src/pages/Signup.vue
+++ b/cmd/wallet-web/src/pages/Signup.vue
@@ -79,7 +79,9 @@
                   {{ t('Signup.heading') }}
                 </h1>
               </div>
-              <div class="grid grid-cols-1 gap-5 w-full h-64 mb-8 content-center">
+              <div
+                class="grid grid-cols-1 gap-5 w-full h-64 mb-8 content-center justify-items-center"
+              >
                 <Spinner v-if="loading" />
                 <button
                   v-for="(provider, index) in providers"
@@ -87,6 +89,7 @@
                   :key="index"
                   class="
                     items-center
+                    w-full
                     h-11
                     text-sm
                     font-bold


### PR DESCRIPTION

<img width="1671" alt="Screen Shot 2021-12-22 at 10 45 45 AM" src="https://user-images.githubusercontent.com/7862595/147119743-02c08e09-1d9b-47d1-851a-7a077ff09ea3.png">
<img width="1678" alt="Screen Shot 2021-12-22 at 10 45 57 AM" src="https://user-images.githubusercontent.com/7862595/147119755-76c8e89a-cff2-4360-8b3c-bb0496565f20.png">

closes #1368

Signed-off-by: talwinder50 <talwinderkaur50@gmail.com>