### PR TITLE
fix: update CHAPI wallet name to wallet url

### DIFF
--- a/scripts/run_ui_automation.sh
+++ b/scripts/run_ui_automation.sh
@@ -56,7 +56,8 @@ healthCheck() {
 # healthcheck
 healthCheck wallet-web https://wallet.trustbloc.local:8091/healthcheck 200
 healthCheck wallet-web-2 https://wallet-2.trustbloc.local:8071/healthcheck 200
-healthCheck wallet-server https://localhost:8090/healthcheck 200
+healthCheck wallet-server https://wallet-server.trustbloc.local:8090/healthcheck 200
+healthCheck hub-auth https://hub-auth.trustbloc.local:8044/healthcheck 200
 
 echo "running tests..."
 cd $ROOT/test/ui-automation

--- a/test/ui-automation/wdio.conf.js
+++ b/test/ui-automation/wdio.conf.js
@@ -10,7 +10,8 @@ import {config} from "./wdio.shared.conf";
 
 exports.config = {
   ...config,
-  walletName: "TrustBloc Wallet",
+  // TODO: changed this to url - fix wallet name issue
+  walletName: "wallet.trustbloc.local",
   walletURL: "https://wallet.trustbloc.local:8091",
   walletURLFrench: "https://wallet.trustbloc.local:8091/fr/",
   demoVerifierURL: "https://demo-adapter.trustbloc.local:8094/verifier",


### PR DESCRIPTION
wallet name is not displayed in CHAPI window in latest chrom

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>