### PR TITLE
test: update mock issuer/verifier to support different type of flows

### DIFF
--- a/test/mock/adapter/templates/issuer/issuer.html
+++ b/test/mock/adapter/templates/issuer/issuer.html
@@ -1,0 +1,30 @@
+<!--
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+ -->
+
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="utf-8" />
+    <title>Demo Issuer</title>
+    <script type="text/javascript">
+      function submitAction( action ){
+        document.getElementById("waci-issuance-form").action = action
+      }
+    </script>
+  </head>
+
+  <body>
+    <h1>Demo Issuer</h1>
+
+    <h3>Please click below links to test different issuance flows</h3>
+    
+    <ul>
+      <li id="waci"><a href="/issuer/waci">Wallet and Credential Interaction (WACI)</a></li>
+      <li id="chapi"><a href="/web-wallet">Credential Handler API (CHAPI)</a></li>
+    </ul>
+</body>
+</html>

--- a/test/mock/adapter/templates/issuer/waci-issuer.html
+++ b/test/mock/adapter/templates/issuer/waci-issuer.html
@@ -18,9 +18,8 @@ SPDX-License-Identifier: Apache-2.0
   </head>
 
   <body>
-    <h1>Demo Issuer Adapter</h1>
+    <h1>WACI Issuance Demo</h1>
 
-    <h2>WACI Issuance Demo</h2>
     <form action="" id="waci-issuance-form">
       <label>Wallet URL</label><br />
       <input
@@ -32,8 +31,8 @@ SPDX-License-Identifier: Apache-2.0
       />
       <br />
       <br />
-      <input type="submit" id="waci-issuance-demo" value="Demo" onclick="javascript:submitAction('/waci-issuance')" />
-      <input type="submit" id="waci-issuance-demo-v2" value="Demo V2" onclick="javascript:submitAction('/waci-issuance-v2')" />
+      <input type="submit" id="waci-issuance-demo" value="Demo (DIDComm v1)" onclick="javascript:submitAction('/issuer/waci-issuance')" />
+      <input type="submit" id="waci-issuance-demo-v2" value="Demo (DIDComm v2)" onclick="javascript:submitAction('/issuer/waci-issuance-v2')" />
     </form>
 
     <br />

--- a/test/mock/adapter/templates/verifier/oidc-verifier.html
+++ b/test/mock/adapter/templates/verifier/oidc-verifier.html
@@ -12,16 +12,15 @@ SPDX-License-Identifier: Apache-2.0
     <title>Demo Verifier</title>
     <script type="text/javascript">
       function submitAction( action ){
-        document.getElementById("waci-share-form").action = action
+        document.getElementById("oidc-share-form").action = action
       }
     </script>
   </head>
 
   <body>
-    <h1>Demo Verifier Adapter</h1>
+    <h1>OIDC Share Demo</h1>
 
-    <h2>WACI Share Demo</h2>
-    <form action="" id="waci-share-form">
+    <form action="" id="oidc-share-form">
       <label>Wallet URL</label><br />
       <input
         type="text"
@@ -32,8 +31,8 @@ SPDX-License-Identifier: Apache-2.0
       />
       <br />
       <br />
-      <input type="submit" id="waci-share-demo" value="Demo" onclick="javascript:submitAction('/waci-share')"/>
-      <input type="submit" id="waci-share-demo-v2" value="Demo V2" onclick="javascript:submitAction('/waci-share-v2')"/>
+
+      <p> TODO: Pending implementation </p>
     </form>
 
     <br />

--- a/test/mock/adapter/templates/verifier/verifier.html
+++ b/test/mock/adapter/templates/verifier/verifier.html
@@ -1,0 +1,26 @@
+<!--
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+ -->
+
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="utf-8" />
+    <title>Demo Verifier</title>
+  </head>
+
+  <body>
+    <h1>Demo Verifier</h1>
+
+    <h3>Please click below links to test different verification flows</h3>
+    
+    <ul>
+      <li id="waci"><a href="/verifier/waci">Wallet and Credential Interaction (WACI)</a></li>
+      <li id="oidc"><a href="/verifier/oidc">OpenID Connect for Verifiable Presentation (OIDC4VP)</a></li>
+      <li id="chapi"><a href="/web-wallet">Credential Handler API (CHAPI)</a></li>
+    </ul>
+</body>
+</html>

--- a/test/mock/adapter/templates/verifier/waci-verifier.html
+++ b/test/mock/adapter/templates/verifier/waci-verifier.html
@@ -1,0 +1,43 @@
+<!--
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+ -->
+
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="utf-8" />
+    <title>Demo Verifier</title>
+    <script type="text/javascript">
+      function submitAction( action ){
+        document.getElementById("waci-share-form").action = action
+      }
+    </script>
+  </head>
+
+  <body>
+    <h1>WACI Share Demo</h1>
+
+    <form action="" id="waci-share-form">
+      <label>Wallet URL</label><br />
+      <input
+        type="text"
+        id="walletURL"
+        name="walletURL"
+        value="https://wallet.trustbloc.local:8091"
+        size="50"
+      />
+      <br />
+      <br />
+      <input type="submit" id="waci-share-demo" value="Demo (DIDComm v1)" onclick="javascript:submitAction('/verifier/waci-share')"/>
+      <input type="submit" id="waci-share-demo-v2" value="Demo (DIDComm v2)" onclick="javascript:submitAction('/verifier/waci-share-v2')"/>
+    </form>
+
+    <br />
+    <br />
+
+    <b>{{.Msg}} </b>
+  </body>
+</html>

--- a/test/ui-automation/test/specs/credential-interaction-flow.js
+++ b/test/ui-automation/test/specs/credential-interaction-flow.js
@@ -276,7 +276,7 @@ describe("TrustBloc Wallet - Store/Share credential flow (CHAPI)", () => {
 
   it(`User performs DID Auth with mock issuer`, async function () {
     // mock issuer (wallet page with sample requests)
-    await browser.navigateTo(browser.config.webWalletURL);
+    await browser.navigateTo(browser.config.chapiDemoURL);
 
     const didAuthBtn = await $("#didauth");
     await didAuthBtn.waitForExist();
@@ -302,7 +302,7 @@ describe("TrustBloc Wallet - Store/Share credential flow (CHAPI)", () => {
   it(`User stores credential from mock issuer`, async function () {
     for (const [key, value] of credential.entries()) {
       // mock issuer (wallet page with sample requests)
-      await browser.navigateTo(browser.config.webWalletURL);
+      await browser.navigateTo(browser.config.chapiDemoURL);
 
       console.log("save vc : start ", key);
 
@@ -396,7 +396,7 @@ describe("TrustBloc Wallet - Store/Share credential flow (CHAPI)", () => {
   it(`User shares the saved credential with mock verifier`, async function () {
     for (const [key, value] of credential.entries()) {
       // mock verifier (wallet page with sample requests)
-      await browser.navigateTo(browser.config.webWalletURL);
+      await browser.navigateTo(browser.config.chapiDemoURL);
 
       console.log("share vc : start ", key);
 

--- a/test/ui-automation/test/specs/waci-flow.js
+++ b/test/ui-automation/test/specs/waci-flow.js
@@ -72,7 +72,7 @@ async function waciFlow(version, ctx) {
 
   it(`User offered to save credential through WACI-Issuance (Redirect) : user (${ctx.email}) signed-in`, async function () {
     // demo issuer page
-    await browser.navigateTo(browser.config.demoIssuerURL);
+    await browser.navigateTo(browser.config.waciDemoIssuerURL);
 
     let waciIssuanceDemoBtn;
 
@@ -103,7 +103,7 @@ async function waciFlow(version, ctx) {
 
   it(`User presents credential through WACI-Share (Redirect) : already signed-in`, async function () {
     // demo verifier page
-    await browser.navigateTo(browser.config.demoVerifierURL);
+    await browser.navigateTo(browser.config.waciDemoVerifierURL);
 
     let waciShareDemoBtn;
 

--- a/test/ui-automation/wdio.conf.js
+++ b/test/ui-automation/wdio.conf.js
@@ -8,13 +8,16 @@ SPDX-License-Identifier: Apache-2.0
 
 import {config} from "./wdio.shared.conf";
 
+const mockDemoDomain = "https://demo-adapter.trustbloc.local:8094"
+
+
 exports.config = {
   ...config,
   // TODO: changed this to url - fix wallet name issue
   walletName: "wallet.trustbloc.local",
   walletURL: "https://wallet.trustbloc.local:8091",
   walletURLFrench: "https://wallet.trustbloc.local:8091/fr/",
-  demoVerifierURL: "https://demo-adapter.trustbloc.local:8094/verifier",
-  demoIssuerURL: "https://demo-adapter.trustbloc.local:8094/issuer",
-  webWalletURL: "https://demo-adapter.trustbloc.local:8094/web-wallet",
+  waciDemoVerifierURL:  mockDemoDomain + "/verifier/waci",
+  waciDemoIssuerURL: mockDemoDomain + "/issuer/waci",
+  chapiDemoURL: mockDemoDomain + "/web-wallet",
 };


### PR DESCRIPTION
- Added a issuer/verifier home page to direct users to different type of flows (waci, oidc, etc)
- Update waci demo button names
- Add oidc share flow TODO page

refactor to support new flows like #1529

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>