### PR TITLE
test: [oidc4vp] display success/error message, id_token and vp_token

### DIFF
--- a/test/mock/adapter/adapter.go
+++ b/test/mock/adapter/adapter.go
@@ -389,13 +389,26 @@ func (v *adapterApp) oidcShareCallback(w http.ResponseWriter, r *http.Request) {
 
 	_, err = verifiable.ParsePresentation([]byte(vpToken), verifiable.WithPresJSONLDDocumentLoader(ld.NewDefaultDocumentLoader(nil)))
 	if err != nil {
-		handleError(w, http.StatusInternalServerError,
-			fmt.Sprintf("failed to validate presentation : %s", err))
+		loadTemplate(w, oidcVerifierHTML,
+			map[string]interface{}{
+				"ErrMsg":                    fmt.Sprintf("ERROR: failed to validate presentation : %s", err),
+				"ID_TOKEN":                  "ID_TOKEN:\n" + idToken,
+				"DECODED_VPDEF_IN_ID_TOKEN": "DECODED_VPDEF_IN_ID_TOKEN: " + string(presSubBytes),
+				"VP_TOKEN":                  "VP_TOKEN: " + string(vpToken),
+			},
+		)
 
 		return
 	}
 
-	loadTemplate(w, oidcVerifierHTML, map[string]interface{}{"Msg": "Successfully Received Presentation"})
+	loadTemplate(w, oidcVerifierHTML,
+		map[string]interface{}{
+			"Msg":                       "Successfully Received Presentation",
+			"ID_TOKEN":                  "ID_TOKEN:\n" + idToken,
+			"DECODED_VPDEF_IN_ID_TOKEN": "DECODED_VPDEF_IN_ID_TOKEN: " + string(presSubBytes),
+			"VP_TOKEN":                  "VP_TOKEN: " + string(vpToken),
+		},
+	)
 }
 
 func listenForDIDCommMsg(actionCh chan service.DIDCommAction, store storage.Store) {

--- a/test/mock/adapter/templates/verifier/oidc-verifier.html
+++ b/test/mock/adapter/templates/verifier/oidc-verifier.html
@@ -63,5 +63,20 @@ SPDX-License-Identifier: Apache-2.0
     <br />
 
     <b>{{.Msg}} </b>
+    <br />
+
+    <b style="color:red;">{{.ErrMsg}} </b>
+
+    <br />
+
+    <p>{{.ID_TOKEN}} </p>
+    <br />
+
+    <p>{{.DECODED_VPDEF_IN_ID_TOKEN}} </p>
+    <br />
+
+    <p>{{.VP_TOKEN}} </p>
+    <br />
+
   </body>
 </html>


### PR DESCRIPTION


https://user-images.githubusercontent.com/10111768/159350564-749349e0-e266-4a8d-8923-01b4c930219e.mov



closes #1585 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>