### PR TITLE
feat: Implement rename credential change

### DIFF
--- a/cmd/wallet-web/src/components/CredentialDetails/DeleteCredentialModal.vue
+++ b/cmd/wallet-web/src/components/CredentialDetails/DeleteCredentialModal.vue
@@ -24,11 +24,11 @@
           </svg>
         </div>
         <span class="pt-5 pb-3 text-lg font-bold text-neutrals-dark">
-          {{ t('CredentialDetails.deleteCredential') }}?
+          {{ t('CredentialDetails.DeleteModal.deleteCredential') }}?
         </span>
         <div class="relative flex-auto">
           <p class="pb-12 text-base text-center text-neutrals-medium">
-            {{ t('CredentialDetails.deleteCredentialConfirmMessage') }}
+            {{ t('CredentialDetails.DeleteModal.deleteCredentialConfirmMessage') }}
           </p>
         </div>
       </div>
@@ -40,7 +40,7 @@
         type="danger"
         @click="deleteCredential()"
       >
-        {{ t('CredentialDetails.deleteButtonLabel') }}
+        {{ t('CredentialDetails.DeleteModal.deleteButtonLabel') }}
       </styled-button>
     </template>
   </modal>

--- a/cmd/wallet-web/src/components/CredentialDetails/RenameCredentialModal.vue
+++ b/cmd/wallet-web/src/components/CredentialDetails/RenameCredentialModal.vue
@@ -1,0 +1,189 @@
+<!--
+ * Copyright SecureKey Technologies Inc. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+-->
+
+<template>
+  <modal :show="showModal" :show-close-button="true" @close="handleClose">
+    <template #errorToast>
+      <toast-notification
+        v-if="systemError"
+        :title="t('CredentialDetails.RenameModal.errorToast.title')"
+        :description="t('CredentialDetails.RenameModal.errorToast.description')"
+        type="error"
+      />
+    </template>
+    <template #content>
+      <div
+        class="
+          flex
+          justify-between
+          items-center
+          py-4
+          px-8
+          w-full
+          border-b-2 border-neutrals-thistle
+        "
+      >
+        <span class="text-lg font-bold text-neutrals-dark">
+          {{ t('CredentialDetails.RenameModal.renameCredential') }}
+        </span>
+      </div>
+      <div class="flex items-center px-8 pt-10 w-full">
+        <input-field
+          :v-model="credentialName"
+          type="text"
+          :label="t('CredentialDetails.RenameModal.label')"
+          :value="credentialName"
+          :helper-message="t('CredentialDetails.helperMessage')"
+          :error-message="errorMessage"
+          :placeholder="t('CredentialDetails.RenameModal.placeholderLabel')"
+          :pattern="pattern"
+          required
+          :empty-error="t('CredentialDetails.emptyError')"
+          minlength="1"
+          maxlength="52"
+          :submitted="submitted"
+          autocomplete="off"
+          @input="updateCredentialName"
+        />
+      </div>
+    </template>
+    <template #actionButton>
+      <styled-button
+        class="order-first md:order-last w-full md:w-auto"
+        type="primary"
+        :loading="loading"
+        @click="renameCredential(credentialId, vaultName)"
+      >
+        {{ t('CredentialDetails.RenameModal.rename') }}
+      </styled-button>
+    </template>
+  </modal>
+</template>
+
+<script>
+import { computed, ref, watch } from 'vue';
+import { useStore } from 'vuex';
+import { CollectionManager, CredentialManager } from '@trustbloc/wallet-sdk';
+import { useI18n } from 'vue-i18n';
+import Modal from '@/components/Modal/Modal.vue';
+import InputField from '@/components/InputField/InputField';
+import StyledButton from '@/components/StyledButton/StyledButton';
+import ToastNotification from '@/components/ToastNotification/ToastNotification';
+import { credentialMutations } from '@/pages/CredentialDetails';
+
+export default {
+  name: 'RenameCredentialModal',
+  components: { StyledButton, InputField, Modal, ToastNotification },
+  props: {
+    show: {
+      type: Boolean,
+      default: false,
+    },
+    credentialId: {
+      type: String,
+      required: true,
+    },
+    name: {
+      type: String,
+      required: true,
+    },
+    vaultName: {
+      type: String,
+      required: true,
+    },
+  },
+  emits: ['close'],
+  setup(props) {
+    const store = useStore();
+    const agentInstance = computed(() => store.getters['agent/getInstance']);
+    const currentUser = computed(() => store.getters.getCurrentUser);
+    const { t } = useI18n();
+    const showModal = ref(false);
+    watch(
+      () => props.show,
+      (show) => {
+        showModal.value = show;
+      }
+    );
+
+    return { agentInstance, currentUser, showModal, t };
+  },
+  data() {
+    return {
+      credentialName: '',
+      loading: false,
+      submitted: false,
+      systemError: false,
+    };
+  },
+  computed: {
+    errorMessage() {
+      if (this.submitted && this.nameEmpty) {
+        return this.t('CredentialDetails.emptyError');
+      } else if (!this.nameValid) {
+        return this.t('CredentialDetails.patternError');
+      } else return '';
+    },
+    // Returns true if the length of the trimmed name is 0
+    nameEmpty() {
+      return this.credentialName.trim().replace(/ +/g, '\\s+').length === 0;
+    },
+    // Returns true if the name only contains letters, numbers or whitespace characters
+    nameValid() {
+      const re = new RegExp('^[a-zA-Z\\d]+(?:[a-zA-Z\\d\\s]+)*$');
+      return re.test(this.credentialName.trim().replace(/  +/g, ' '));
+    },
+    pattern() {
+      return `(^[a-zA-Z\\d]+(?:[a-zA-Z\\d\\s]+)*$)`;
+    },
+  },
+  watch: {
+    showModal: function () {
+      if (!this.showModal.value) {
+        this.submitted = false;
+        this.credentialName = this.name;
+      }
+    },
+  },
+  methods: {
+    updateCredentialName({ name }) {
+      this.credentialName = name;
+      this.submitted = false;
+    },
+    async renameCredential(credentialId, vaultName) {
+      this.submitted = true;
+      if (this.credentialName.length && this.nameValid) {
+        this.loading = true;
+        const { user, token } = this.currentUser.profile;
+        const credentialManager = new CredentialManager({ agent: this.agentInstance, user });
+        const collectionManager = new CollectionManager({ agent: this.agentInstance, user });
+        const { contents } = await collectionManager.getAll(token);
+        this.vaults = Object.values(contents).map((vault) => vault);
+        const vaultID = this.vaults.find((vault) => vault.name === vaultName).id;
+        try {
+          await credentialManager.updateCredentialMetadata(token, credentialId, {
+            name: this.credentialName,
+            collection: vaultID,
+          });
+          credentialMutations.setCredentialOutdated(true);
+          this.showModal = false;
+          this.loading = false;
+          this.submitted = false;
+          this.$emit('close');
+        } catch (e) {
+          this.systemError = true;
+          this.loading = false;
+          console.error('Error while renaming credential:', e);
+        }
+      }
+    },
+    handleClose() {
+      this.showModal = false;
+      this.$emit('close');
+    },
+  },
+};
+</script>

--- a/cmd/wallet-web/src/components/InputField/InputField.vue
+++ b/cmd/wallet-web/src/components/InputField/InputField.vue
@@ -11,6 +11,7 @@
       ref="input"
       v-bind="$attrs"
       :name="name"
+      :value="value"
       :disabled="!characterCount"
       @input="onInput"
       @keyup.enter="characterCount"

--- a/cmd/wallet-web/src/components/Modal/Modal.vue
+++ b/cmd/wallet-web/src/components/Modal/Modal.vue
@@ -19,6 +19,9 @@
       "
       @click.self="close"
     >
+      <div class="flex overflow-y-auto fixed inset-0 justify-center items-center">
+        <slot name="errorToast" />
+      </div>
       <div class="relative flex-grow mx-6 lg:mx-auto max-w-lg rounded-2xl bg-neutrals-white">
         <button v-if="showCloseButton" class="absolute right-0 pt-3 pr-3 w-10 h-10" @click="close">
           <!-- TODO: use inline svg instead once https://github.com/trustbloc/wallet/issues/816 is fixed -->

--- a/cmd/wallet-web/src/components/WACI/CredentialOverview.vue
+++ b/cmd/wallet-web/src/components/WACI/CredentialOverview.vue
@@ -34,7 +34,7 @@
       <span
         class="flex-1 pl-4 text-sm font-bold text-left text-ellipsis"
         :style="`color: ${credential?.styles.text.color}`"
-        >{{ credential?.title }}</span
+        >{{ credentialHeading }}</span
       >
     </div>
     <slot name="bannerBottomContainer" />
@@ -63,7 +63,10 @@ export default {
         ? props?.credential?.styles?.thumbnail?.uri
         : getCredentialIcon(getStaticAssetsUrl(), props?.credential?.styles?.thumbnail?.uri)
     );
-    return { credentialIconSrc };
+    const credentialHeading = computed(() =>
+      props?.credential?.name?.length ? props?.credential?.name : props?.credential?.title
+    );
+    return { credentialIconSrc, credentialHeading };
   },
 };
 </script>

--- a/cmd/wallet-web/src/pages/Credentials.vue
+++ b/cmd/wallet-web/src/pages/Credentials.vue
@@ -162,7 +162,7 @@
                     },
                   }"
                   :styles="credential.styles"
-                  :title="credential.title"
+                  :title="credential.name"
                 />
               </li>
             </ul>
@@ -264,6 +264,7 @@ export default {
         });
         return metadataList.map((credential) => ({
           id: encode(credential.id),
+          name: credential.name,
           ...credential.resolved[0],
         }));
       } catch (e) {

--- a/cmd/wallet-web/src/pages/Vaults.vue
+++ b/cmd/wallet-web/src/pages/Vaults.vue
@@ -157,9 +157,8 @@
 
 <script>
 import { computed, reactive, ref, watchEffect } from 'vue';
-import { useStore } from 'vuex';
 import { CollectionManager, CredentialManager, WalletUser } from '@trustbloc/wallet-sdk';
-import { mapGetters, mapActions } from 'vuex';
+import { mapActions, mapGetters, useStore } from 'vuex';
 import { useI18n } from 'vue-i18n';
 import useBreakpoints from '@/plugins/breakpoints.js';
 import DeleteVault from '@/components/Vaults/DeleteVaultModal';

--- a/cmd/wallet-web/src/pages/WACIIssue.vue
+++ b/cmd/wallet-web/src/pages/WACIIssue.vue
@@ -115,7 +115,7 @@
 <script>
 import { toRaw } from 'vue';
 import { mapGetters } from 'vuex';
-import { CredentialManager, CollectionManager, DIDComm } from '@trustbloc/wallet-sdk';
+import { CollectionManager, CredentialManager, DIDComm } from '@trustbloc/wallet-sdk';
 import { useI18n } from 'vue-i18n';
 import { WACIStore } from '@/layouts/WACI.vue';
 import CustomSelect from '@/components/CustomSelect/CustomSelect.vue';

--- a/cmd/wallet-web/src/pages/WACIShare.vue
+++ b/cmd/wallet-web/src/pages/WACIShare.vue
@@ -140,7 +140,7 @@
             <credential-banner
               :id="credential.id"
               :styles="credential.styles"
-              :title="credential.title"
+              :title="credential.name"
               @click="handleOverviewClick(credential.id)"
             />
           </li>
@@ -167,7 +167,7 @@ import { toRaw } from 'vue';
 import { mapGetters } from 'vuex';
 import { useI18n } from 'vue-i18n';
 import { CredentialManager, DIDComm } from '@trustbloc/wallet-sdk';
-import { WACIStore, WACIMutations } from '@/layouts/WACI.vue';
+import { WACIMutations, WACIStore } from '@/layouts/WACI.vue';
 import { WACIShareLayoutMutations } from '@/layouts/WACIShareLayout.vue';
 import StyledButton from '@/components/StyledButton/StyledButton.vue';
 import CredentialBanner from '@/components/WACI/CredentialBanner.vue';
@@ -264,13 +264,11 @@ export default {
         );
         await credentials.map(async (credential) => {
           // getCredentialMetadata
-          const { id, issuanceDate, resolved } = await this.credentialManager.getCredentialMetadata(
-            this.token,
-            credential.id
-          );
+          const { id, name, issuanceDate, resolved } =
+            await this.credentialManager.getCredentialMetadata(this.token, credential.id);
           // TODO: issue1410 - add logic to retrieve the list of vaults in which the credential is stored
           const vaultName = 'Unavailable';
-          this.processedCredentials.push({ id, issuanceDate, ...resolved[0], vaultName });
+          this.processedCredentials.push({ id, name, issuanceDate, ...resolved[0], vaultName });
         });
       } catch (e) {
         this.errors.push('No credentials found matching requested criteria.');

--- a/cmd/wallet-web/src/translations/CredentialDetails/en.json
+++ b/cmd/wallet-web/src/translations/CredentialDetails/en.json
@@ -1,18 +1,35 @@
 {
-  "heading": "Credentials details",
+  "allVaultLabel": "All Vaults",
   "Banner": {
     "addedOn": "Added on",
     "expiresOn": "Expires on",
     "lastUsed": "Last used",
     "vault": "Vault"
   },
-  "verifiedInformation": "Verified information",
+  "DeleteModal": {
+    "deleteCredential": "Delete Credential",
+    "deleteButtonLabel": "Delete",
+    "deleteCredentialConfirmMessage": "You'll no longer be able to share this credential."
+  },
+  "emptyError": "Can't be empty. Please enter a name.",
+  "heading": "Credentials details",
+  "helperMessage": "Use letters and/or numbers",
+  "label": "Credential Name",
+  "MoveModal": {
+    "moveCredential": "Move Credential"
+  },
+  "patternError": "Must use letters (A-Z) and/or numbers (1-9)",
+  "RenameModal": {
+    "rename": "Rename",
+    "label": "Credential Name",
+    "renameCredential": "Rename Credential",
+    "placeholderLabel": "Enter a credential name . . .",
+    "errorToast": {
+      "title": "Unable to Rename Credential",
+      "description": "Sorry, something went wrong. Please try again."
+    }
+  },
   "saveCredential": "Save credential",
   "toolTipLabel": "Manage credential",
-  "allVaultLabel": "All Vaults",
-  "renameCredential": "Rename Credential",
-  "moveCredential": "Move Credential",
-  "deleteCredential": "Delete Credential",
-  "deleteButtonLabel": "Delete",
-  "deleteCredentialConfirmMessage": "You'll no longer be able to share this credential."
+  "verifiedInformation": "Verified information"
 }

--- a/cmd/wallet-web/src/translations/CredentialDetails/fr.json
+++ b/cmd/wallet-web/src/translations/CredentialDetails/fr.json
@@ -1,18 +1,35 @@
 {
-  "heading": "Renseignements de l’identifiant",
+  "allVaultLabel": "Ajouter une chambre forte",
   "Banner": {
     "addedOn": "Ajouté le",
     "expiresOn": "A expiré le",
     "lastUsed": "Dernière utilisation",
     "vault": "Chambre forte"
   },
-  "verifiedInformation": "Information vérifiée",
+  "DeleteModal": {
+    "deleteCredential": "Supprimer l’identifiant",
+    "deleteButtonLabel": "Supprimer",
+    "deleteCredentialConfirmMessage": "Vous ne pourrez plus partager cet preuve d’identité."
+  },
+  "emptyError": "Ne peut être laissé vide. Veuillez entrer un nom.",
+  "heading": "Renseignements de l’identifiant",
+  "helperMessage": "Utiliser des lettres et/ou des chiffres",
+  "label": "Nom de la chambre forte",
+  "MoveModal": {
+    "moveCredential": "Déplacer l’identifiant"
+  },
+  "patternError": "Vous devez utiliser des lettres (A à Z) ou des chiffres (1 à 9).",
+  "RenameModal": {
+    "rename": "Renommer",
+    "label": "Nom de l’preuve d’identité",
+    "renameCredential": "Renommer l’preuve d’identité",
+    "placeholderLabel": "Entrer le nom de l’identifiant...",
+    "errorToast": {
+      "title": "Impossible de renommer l'identifiant",
+      "description": "Désolé, quelque chose s'est mal passé. Veuillez réessayer."
+    }
+  },
   "saveCredential": "Sauvegarder la preuve d’identité",
   "toolTipLabel": "Gérer l’identifiant",
-  "allVaultLabel": "Ajouter une chambre forte",
-  "renameCredential": "Renommer l’identifiant",
-  "moveCredential": "Déplacer l’identifiant",
-  "deleteCredential": "Supprimer l’identifiant",
-  "deleteButtonLabel": "Supprimer",
-  "deleteCredentialConfirmMessage": "Vous ne pourrez plus partager cet preuve d’identité."
+  "verifiedInformation": "Information vérifiée"
 }


### PR DESCRIPTION
partof #1516

- Regarding validation as discussed with UX team, As long as there is a way for the user to differentiate credentials we dont have a problem. Either by different look, or by different name. Therefore removing same name validation for now as discussed with the team


<img width="932" alt="Screen Shot 2022-03-21 at 7 14 54 PM" src="https://user-images.githubusercontent.com/7862595/159378827-1a6924cb-1ea1-499c-8442-8a64924e970c.png">
<img width="334" alt="Screen Shot 2022-03-21 at 7 15 29 PM" src="https://user-images.githubusercontent.com/7862595/159378828-8159b438-3db9-463d-b65d-25cf198127d8.png">
<img width="339" alt="Screen Shot 2022-03-21 at 7 15 39 PM" src="https://user-images.githubusercontent.com/7862595/159378829-c80994f6-44aa-401f-8677-400a39497958.png">




Signed-off-by: talwinder50 <talwinderkaur50@gmail.com>

https://user-images.githubusercontent.com/7862595/159482503-3647db06-06d7-4dcb-bff5-da24f29bed3c.mov

Updated video

https://user-images.githubusercontent.com/7862595/159603351-dce1f619-c57e-4de4-a37a-b62e091cda15.mp4

- Fixed -> - Fixed when the modal is opened it should show the existing name as a placeholder text. 
<img width="1680" alt="Screen Shot 2022-03-22 at 8 52 08 PM" src="https://user-images.githubusercontent.com/7862595/159603506-dc1a9275-8d7e-4e75-af00-44d1296c873a.png">
- When entering the new valid name the bottom border of the input field is not red now 
<img width="1680" alt="Screen Shot 2022-03-22 at 8 52 20 PM" src="https://user-images.githubusercontent.com/7862595/159603634-bea5ba57-c791-41cc-aa26-66911912c42d.png">
<img width="1680" alt="Screen Shot 2022-03-22 at 8 52 08 PM" src="https://user-images.githubusercontent.com/7862595/159603687-def8b907-b041-4daa-ae5c-a1a8128c1db0.png">
<img width="1680" alt="Screen Shot 2022-03-22 at 8 52 20 PM" src="https://user-images.githubusercontent.com/7862595/159603691-f1de63a3-9713-4593-8ab3-91938deca485.png">
<img width="1679" alt="Screen Shot 2022-03-22 at 8 52 28 PM" src="https://user-images.githubusercontent.com/7862595/159603693-62627207-8937-4b08-ad4a-309743be5935.png">
<img width="1677" alt="Screen Shot 2022-03-22 at 8 52 44 PM" src="https://user-images.githubusercontent.com/7862595/159603694-135af471-6e51-4476-8561-570c40b9641c.png">
<img width="1680" alt="Screen Shot 2022-03-22 at 8 52 53 PM" src="https://user-images.githubusercontent.com/7862595/159603696-8974f724-5ca0-4e22-b163-638cfbac4452.png">
<img width="1680" alt="Screen Shot 2022-03-22 at 8 53 00 PM" src="https://user-images.githubusercontent.com/7862595/159603698-f783ec9f-b71f-481b-88f3-ceb5124490c6.png">
<img width="1679" alt="Screen Shot 2022-03-22 at 8 53 11 PM" src="https://user-images.githubusercontent.com/7862595/159603699-3e90c9f8-14d4-4ce7-8276-1e6af767c04c.png">

- 
<img width="1677" alt="Screen Shot 2022-03-22 at 8 27 14 PM" src="https://user-images.githubusercontent.com/7862595/159603733-befd6aab-024c-4034-bfdf-b671ab33c075.png">

<img width="1011" alt="Screen Shot 2022-03-22 at 9 28 42 PM" src="https://user-images.githubusercontent.com/7862595/159603915-6b7f1dd3-55e6-4333-8756-49f7560fd684.png">
