### PR TITLE
fix: rename Vue components to have multi-worded names 

### DIFF
--- a/cmd/wallet-web/src/components/SkeletonLoader/SkeletonLoaderComponent.vue
+++ b/cmd/wallet-web/src/components/SkeletonLoader/SkeletonLoaderComponent.vue
@@ -15,7 +15,7 @@
 </template>
 
 <script>
-import VaultCard from './VaultCardComponent';
+import VaultCardComponent from './VaultCardComponent';
 export default {
   components: {
     VaultCardComponent,


### PR DESCRIPTION
There was one component I missed and did not add the `Component` suffix to from the[ last PR](https://github.com/trustbloc/wallet/pull/1668) for renaming Vue components to be multi-worded. (sorry about that!) 
This PR fixes that and also I verified that all the other components have the `Component` suffix.
Signed-off-by: heidihan0000 <daeun.han@avast.com>