### PR TITLE
fix: apply dynamic focus styles to credential previews

### DIFF
--- a/cmd/wallet-web/src/components/CredentialPreview/CredentialPreviewComponent.vue
+++ b/cmd/wallet-web/src/components/CredentialPreview/CredentialPreviewComponent.vue
@@ -6,6 +6,7 @@
 
 <template>
   <router-link
+    :id="id"
     class="
       group
       inline-flex
@@ -27,11 +28,10 @@
     "
     :class="
       styles.background.color !== '#fff'
-        ? `border-neutrals-black border-opacity-10 focus-within:ring-primary-${styles?.background?.color}`
+        ? `border-neutrals-black border-opacity-10 notWhiteCredentialPreview`
         : `border-neutrals-thistle hover:border-neutrals-chatelle focus-within:ring-neutrals-victorianPewter`
     "
-    :style="`background-color: ${styles?.background?.color}`"
-    :id="id"
+    :style="credentialStyles"
   >
     <div class="flex-none w-12 h-12 border-opacity-10">
       <img :src="credentialIconSrc" />
@@ -96,11 +96,24 @@ export default {
     );
     return { credentialIconSrc };
   },
+  computed: {
+    credentialStyles() {
+      return {
+        'background-color': this.styles?.background?.color,
+        '--focus-color': this.styles?.background?.color,
+      };
+    },
+  },
 };
 </script>
 
 <style scoped>
 .credentialPreviewContainer:not(:focus-within):hover {
   box-shadow: 0px 4px 12px 0px rgba(25, 12, 33, 0.1);
+}
+
+.notWhiteCredentialPreview:focus {
+  outline: 2px solid var(--focus-color);
+  outline-offset: 2px;
 }
 </style>


### PR DESCRIPTION
Closes #1597 : Changed `CredentialPreviewComponent` to use `css` instead of `tailwindcss` for focus style 

Before (light blue focus ring on credentials that are not white)         |  After
:-------------------------:|:-------------------------:
<img width="500" alt="Screen Shot 2022-05-18 at 3 27 37 PM" src="https://user-images.githubusercontent.com/44453261/169142860-5f5ad823-deee-41a0-838a-14f2aecdbb1f.png">  |  <img width="500" alt="Screen Shot 2022-05-18 at 3 10 24 PM" src="https://user-images.githubusercontent.com/44453261/169142759-cebacf93-612f-4a42-8be3-00dd390fabb3.png">
<img width="500" alt="Screen Shot 2022-05-18 at 3 27 56 PM" src="https://user-images.githubusercontent.com/44453261/169142888-5383ffba-0c3d-4a03-b3ce-57818aae08c1.png"> |  <img width="500" alt="Screen Shot 2022-05-18 at 3 10 16 PM" src="https://user-images.githubusercontent.com/44453261/169142736-63cf8395-514b-4b1a-a17e-8a8b22e3eaa1.png">
<img width="500" alt="Screen Shot 2022-05-18 at 3 27 46 PM" src="https://user-images.githubusercontent.com/44453261/169142879-3dc64fec-2bc6-4f09-b9ca-a8bd558463a1.png"> | <img width="500" alt="Screen Shot 2022-05-18 at 3 09 55 PM" src="https://user-images.githubusercontent.com/44453261/169142710-6b49f8cb-bc35-46b6-a55a-2bd3ca78b6fb.png">


Signed-off-by: heidihan0000 <daeun.han@avast.com>