### PR TITLE
feat: Prepare valid gnap request to access agent sdk request access method

### DIFF
--- a/cmd/wallet-web/src/config/gnap-access-token.json
+++ b/cmd/wallet-web/src/config/gnap-access-token.json
@@ -1,0 +1,16 @@
+{
+  "access": [
+    {
+      "type": "trustbloc.dev/types/gnap/userdata-access",
+      "actions": ["read", "write", "update", "delete"],
+      "locations": ["edv.provider.com/api"],
+      "subject-keys": ["sub"]
+    },
+    {
+      "type": "trustbloc.dev/types/gnap/kms-access",
+      "actions": ["sign", "verify", "encrypt", "decrypt"],
+      "locations": ["kms.provider.com/api/user"],
+      "subject-keys": ["sub"]
+    }
+  ]
+}

--- a/cmd/wallet-web/src/mixins/gnap/gnap.js
+++ b/cmd/wallet-web/src/mixins/gnap/gnap.js
@@ -5,28 +5,47 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 import { GNAPClient } from '@trustbloc/wallet-sdk';
+import { computed } from 'vue';
+import store from '@/store';
 
 // TODO Issue-364 Add gnap create key pair logic to agent sdk library
-export async function createKeyPair() {
-  const keyPair = await window.crypto.subtle.generateKey(
+export function createKeyPair() {
+  return window.crypto.subtle.generateKey(
     {
       name: 'ECDSA',
       namedCurve: 'P-256',
     },
-    true,
+    false,
     ['sign', 'verify']
   );
-
-  return keyPair;
 }
 
-export async function gnapRequestAccess(signer, gnapAuthServerURL) {
-  // TODO Issue-1709 pass the valid request to agent sdk request access
-  let req;
+export async function gnapRequestAccess(signer) {
+  const gnapAccessTokenConfig = computed(() => store.getters['getGnapAccessTokenConfig']);
+  const gnapAccessTokens = await gnapAccessTokenConfig.value;
+  const gnapAuthServerURL = computed(() => store.getters['hubAuthURL']).value;
+  const gnapWalletCallBackURL = computed(() => store.getters['getStaticAssetsUrl']).value;
+
+  const exportedJwk = await window.crypto.subtle.exportKey('jwk', signer.SignatureVal.publicKey);
+  //TODO Issue-1699 persist nonce value and add valid uri in the request
+  const nonceVal = 'wallet-nonce';
+  const gnapReq = {
+    access_token: [gnapAccessTokens],
+    client: { key: { jwk: exportedJwk } },
+    interact: {
+      start: ['redirect'],
+      finish: {
+        method: 'redirect',
+        uri: gnapWalletCallBackURL,
+        nonce: nonceVal,
+      },
+    },
+  };
+
   const gnapClient = new GNAPClient({
     signer: signer,
     gnapAuthServerURL: gnapAuthServerURL,
   });
-  const { resp } = await gnapClient.requestAccess(req);
+  const resp = await gnapClient.requestAccess(gnapReq);
   return resp;
 }

--- a/cmd/wallet-web/src/router/index.js
+++ b/cmd/wallet-web/src/router/index.js
@@ -4,7 +4,6 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-import { computed } from 'vue';
 import { createRouter, createWebHistory } from 'vue-router';
 import store from '@/store';
 import { createKeyPair, gnapRequestAccess } from '@/mixins';
@@ -18,13 +17,11 @@ const router = createRouter({
 router.beforeEach(async (to, from, next) => {
   store.dispatch('agent/flushStore');
   if (to.path === '/gnap') {
+    // TODO Issue-1720 create keypair only once if not found
     const gnapKeyPair = await createKeyPair();
     store.dispatch('updateGnapKeyPair', gnapKeyPair);
-
     const signer = { SignatureVal: gnapKeyPair };
-    const gnapAuthServerURL = computed(() => store.getters['hubAuthURL']);
-
-    const resp = await gnapRequestAccess(signer, gnapAuthServerURL);
+    const resp = await gnapRequestAccess(signer);
     // TODO Issue-1699 Save properties from resp to Vuex/local storage and call GNAPClient.continue() in separate func
   }
   if (to.path === 'gnap/redirect') {

--- a/cmd/wallet-web/src/store/modules/options.js
+++ b/cmd/wallet-web/src/store/modules/options.js
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { toRaw } from 'vue';
 import { v4 as uuidv4 } from 'uuid';
+
 const axios = require('axios').default;
 
 const agentOptsLocation = (l) => `${l}/walletconfig/agent`;
@@ -375,6 +376,15 @@ export default {
         return response.data;
       }
       return require('@/config/credentialDisplayData.js').default;
+    },
+    async getGnapAccessTokenConfig(state) {
+      const staticUrl = state.agentOpts['staticAssetsUrl'];
+      if (staticUrl) {
+        const response = await axios.get(`${staticUrl}/config/gnap-access-token.json`);
+        return response.data;
+      }
+
+      return require('@/config/gnap-access-token.json');
     },
   },
 };

--- a/test/fixtures/wallet-web/.env
+++ b/test/fixtures/wallet-web/.env
@@ -60,7 +60,7 @@ EDV_DATABASE_PREFIX=edv_
 
 # Auth
 AUTH_REST_IMAGE=ghcr.io/trustbloc-cicd/auth
-AUTH_REST_IMAGE_TAG=0.1.9-snapshot-7dfd387
+AUTH_REST_IMAGE_TAG=0.1.9-snapshot-43e9a83
 
 # OIDC configurations
 HYDRA_IMAGE_TAG=v1.3.2-alpine

--- a/test/fixtures/wallet-web/static/config/gnap-access-token.json
+++ b/test/fixtures/wallet-web/static/config/gnap-access-token.json
@@ -1,0 +1,15 @@
+{
+	"access": [{
+			"type": "trustbloc.dev/types/gnap/userdata-access",
+			"actions": ["read", "write", "update", "delete"],
+			"locations": ["edv.provider.com/api"],
+			"subject-keys": ["sub"]
+		},
+		{
+			"type": "trustbloc.dev/types/gnap/kms-access",
+			"actions": ["sign", "verify", "encrypt", "decrypt"],
+			"locations": ["kms.provider.com/api/user"],
+			"subject-keys": ["sub"]
+		}
+	]
+}


### PR DESCRIPTION


closes #1709

Signed-off-by: talwinder50 <talwinderkaur50@gmail.com>
<img width="493" alt="Screen Shot 2022-06-16 at 12 24 00 AM" src="https://user-images.githubusercontent.com/7862595/173992869-bdb4bee9-08c2-42e9-9076-62bcab35162e.png">


I get 401 error which is expected until http signer is in ERROR access policy failed to handle access request: client request verification failure: request with body should have a content-digest header
