### PR TITLE
fix: CHAPI Multiple Credential Share failure

### DIFF
--- a/cmd/wallet-web/src/mixins/common/helper.js
+++ b/cmd/wallet-web/src/mixins/common/helper.js
@@ -301,6 +301,7 @@ export function prepareCredentialManifest(presentation, manifestDictionary, issu
     version: '0.1.0',
     output_descriptors: [],
   };
+  let uniqueOutputDescriptors = new Set();
 
   let fulfillment = {
     id: uuidv4(),
@@ -315,7 +316,7 @@ export function prepareCredentialManifest(presentation, manifestDictionary, issu
       credential
     );
     if (entry) {
-      credentialManifest.output_descriptors.push(...entry['output_descriptors']);
+      uniqueOutputDescriptors.add(...entry['output_descriptors']);
     } else {
       // find default output descriptor
       entry = _findOutputDescriptor(manifestDictionary['VerifiableCredential'], credential);
@@ -332,7 +333,7 @@ export function prepareCredentialManifest(presentation, manifestDictionary, issu
           });
         }
 
-        credentialManifest.output_descriptors.push(...entry['output_descriptors']);
+        uniqueOutputDescriptors.add(...entry['output_descriptors']);
       } else {
         console.error(
           "couldn't find default credential manifest for given credential",
@@ -353,5 +354,6 @@ export function prepareCredentialManifest(presentation, manifestDictionary, issu
 
   presentation['credential_fulfillment'] = fulfillment;
 
+  credentialManifest.output_descriptors = Array.from(uniqueOutputDescriptors);
   return credentialManifest;
 }


### PR DESCRIPTION
Closes #1729 

Was able to reproduce locally by:
- Removing all credential output descriptors but "`VerifiableCredential`" (which is the default if the output descriptor cannot be found) in `credential-output-descriptors.json`
- In `readManifests` in `options.js`, comment [this line](https://github.com/trustbloc/wallet/blob/4b2d9826aaf36a57c1174f025a499a2559bd8ec9/cmd/wallet-web/src/store/modules/options.js#L396) so the local output descriptor file gets used.
- Save a PR card and University credential to wallet
- Use MultipleQuery 1 to query for a PR card and University credential - the error is seen here

Fix: To use a Set to add only unique `output_descriptors` to `credentialManifest`

Signed-off-by: heidihan0000 <daeun.han@avast.com>