### PR TITLE
fix: Added spinner as loading state for user authentication 

### DIFF
--- a/cmd/wallet-web/src/App.vue
+++ b/cmd/wallet-web/src/App.vue
@@ -5,7 +5,7 @@
 -->
 
 <script setup>
-import { onBeforeMount, onMounted, onUnmounted, ref } from 'vue';
+import { onBeforeMount, onMounted, onUnmounted, ref, computed } from 'vue';
 import { useStore } from 'vuex';
 import getStartingLocale from '@/mixins/i18n/getStartingLocale.js';
 import { updateI18nLocale } from '@/plugins/i18n';
@@ -13,19 +13,17 @@ import SpinnerIcon from '@/components/icons/SpinnerIcon.vue';
 
 // Local Variables
 const startingLocale = getStartingLocale(); // Get starting locale, set it in i18n and in the store
-const loaded = ref(false);
 
 // Hooks
 const store = useStore();
+
+// Store Getters
+const userLoaded = computed(() => store.getters['isUserLoaded']);
 
 store.dispatch('setLocale', startingLocale);
 
 onBeforeMount(async () => {
   await updateI18nLocale(startingLocale.id);
-});
-
-onMounted(() => {
-  loaded.value = true;
 });
 
 onUnmounted(() => {
@@ -37,7 +35,7 @@ onUnmounted(() => {
 </script>
 <template>
   <div class="w-screen h-screen font-sans bg-neutrals-mischka">
-    <div v-if="!loaded" class="flex relative top-1/3 flex-col justify-start items-center">
+    <div v-if="!userLoaded" class="flex relative top-1/3 flex-col justify-start items-center">
       <SpinnerIcon />
       <span class="mt-6">Loading Wallet . . .</span>
     </div>

--- a/cmd/wallet-web/src/router/index.js
+++ b/cmd/wallet-web/src/router/index.js
@@ -60,6 +60,7 @@ router.beforeEach(async (to, from) => {
         // later on, if we need to authenticate the same user again we just call requestAccess
         // if needed, it will return us a new continue access token to complete user authentication
         store.dispatch('updateGnapReqAccessResp', null);
+        store.dispatch('updateUserLoaded', true);
 
         return { name: 'DashboardLayout' };
       }
@@ -79,8 +80,8 @@ router.beforeEach(async (to, from) => {
         } catch (e) {
           console.error('error initializing agent for existing user:', e);
         }
-        return;
       }
+      store.dispatch('updateUserLoaded', true);
       return;
     } else if (store.dispatch('loadUser') && store.getters.getCurrentUser) {
       if (!store.getters['agent/isInitialized']) {
@@ -94,8 +95,8 @@ router.beforeEach(async (to, from) => {
         } catch (e) {
           console.error('error initializing agent for existing user:', e);
         }
-        return;
       }
+      store.dispatch('updateUserLoaded', true);
       return;
     } else {
       // User is not authenticated, request access from auth server
@@ -130,8 +131,8 @@ router.beforeEach(async (to, from) => {
           } catch (e) {
             console.error('error initializing agent for new user:', e);
           }
-          return;
         }
+        store.dispatch('updateUserLoaded', true);
         return;
       }
 
@@ -160,8 +161,8 @@ router.beforeEach(async (to, from) => {
         } catch (e) {
           console.error('error initializing agent for existing user:', e);
         }
-        return;
       }
+      store.dispatch('updateUserLoaded', true);
       return;
     } else if (store.dispatch('loadUser') && store.getters.getCurrentUser) {
       if (!store.getters['agent/isInitialized']) {
@@ -175,10 +176,11 @@ router.beforeEach(async (to, from) => {
         } catch (e) {
           console.error('error initializing agent for existing user:', e);
         }
-        return;
       }
+      store.dispatch('updateUserLoaded', true);
       return;
     } else {
+      store.dispatch('updateUserLoaded', true);
       return {
         name: 'block-no-auth',
         params: {
@@ -199,10 +201,9 @@ router.beforeEach(async (to, from) => {
         },
         query: to.query,
       });
-      return;
-    } else {
-      return;
     }
+    store.dispatch('updateUserLoaded', true);
+    return;
   }
 });
 

--- a/cmd/wallet-web/src/store/modules/user.js
+++ b/cmd/wallet-web/src/store/modules/user.js
@@ -19,6 +19,7 @@ export default {
     profile: null,
     loggedIn: false,
     logInSuspended: false,
+    loaded: false,
     chapi: false,
     selectedVaultId: null,
     selectedCredentialId: null,
@@ -63,6 +64,9 @@ export default {
     setLogInSuspended(state) {
       state.logInSuspended = true;
     },
+    setLoaded(state, val) {
+      state.loaded = val;
+    },
     setSelectedVaultId(state, val) {
       state.selectedVaultId = val;
       if (val !== null) {
@@ -104,6 +108,7 @@ export default {
       state.setupStatus = null;
       state.profile = null;
       state.loggedIn = false;
+      state.loaded = false;
       state.chapi = false;
       state.selectedVaultId = null;
       state.selectedCredentialId = null;
@@ -179,6 +184,9 @@ export default {
     updateLoginSuspended({ commit }) {
       commit('setLogInSuspended');
     },
+    updateUserLoaded({ commit }, loaded) {
+      commit('setLoaded', loaded);
+    },
     activateCHAPI({ commit }) {
       commit('setCHAPI', true);
     },
@@ -214,6 +222,9 @@ export default {
     },
     isLoginSuspended(state) {
       return state.logInSuspended;
+    },
+    isUserLoaded(state) {
+      return state.loaded;
     },
     isCHAPI(state) {
       return state.chapi;


### PR DESCRIPTION
Related to #1809 
Added the Spinner icon to indicate to user that the wallet is loading while finishing user authentication. 
This was added as a temporary fix; in the future, the loading state should be the skeleton loaders for the corresponding page. 
Signed-off-by: heidihan0000 <daeun.han@avast.com>

https://user-images.githubusercontent.com/44453261/180890467-3c834808-9927-44da-8038-708ed41b7a58.mov

