### PR TITLE
fix: use title from credentialmanifest

### DIFF
--- a/cmd/wallet-web/src/pages/CredentialDetailsPage.vue
+++ b/cmd/wallet-web/src/pages/CredentialDetailsPage.vue
@@ -5,20 +5,20 @@
 -->
 <template>
   <!-- Loading State -->
-  <div v-if="loading" class="flex flex-col justify-start items-start py-6 px-3">
-    <div class="flex flex-row justify-between items-center mb-4 w-full">
+  <div v-if="loading" class="flex flex-col items-start justify-start py-6 px-3">
+    <div class="mb-4 flex w-full flex-row items-center justify-between">
       <h3 class="text-neutrals-dark">{{ t('CredentialDetails.heading') }}</h3>
     </div>
     <SkeletonLoaderComponent type="CredentialDetailsBanner" />
-    <div class="flex flex-col justify-start items-start mt-8 w-full md:mt-2">
+    <div class="mt-8 flex w-full flex-col items-start justify-start md:mt-2">
       <span class="mb-5 text-xl font-bold text-neutrals-dark">{{
         t('CredentialDetails.verifiedInformation')
       }}</span>
       <SkeletonLoaderComponent class="w-full" type="VerifiedInformation" />
     </div>
   </div>
-  <div v-else-if="credential" class="flex flex-col justify-start items-start py-6 px-3">
-    <div class="flex flex-row justify-between items-center mb-4 w-full">
+  <div v-else-if="credential" class="flex flex-col items-start justify-start py-6 px-3">
+    <div class="mb-4 flex w-full flex-row items-center justify-between">
       <div class="flex grow">
         <h3 class="text-neutrals-dark">{{ t('CredentialDetails.heading') }}</h3>
       </div>
@@ -26,7 +26,7 @@
         <template #button="{ toggleFlyoutMenu, setShowTooltip }">
           <button
             id="credential-details-flyout-button"
-            class="w-11 h-11 bg-neutrals-white rounded-lg border border-neutrals-chatelle focus:border-neutrals-chatelle outline-none focus:ring-2 focus:ring-primary-purple focus:ring-opacity-70 focus-within:ring-offset-2 hover:border-neutrals-mountainMist-light"
+            class="h-11 w-11 rounded-lg border border-neutrals-chatelle bg-neutrals-white outline-none focus-within:ring-offset-2 hover:border-neutrals-mountainMist-light focus:border-neutrals-chatelle focus:ring-2 focus:ring-primary-purple focus:ring-opacity-70"
             @click="toggleFlyoutMenu()"
             @focus="setShowTooltip(false)"
             @mouseover="setShowTooltip(true)"
@@ -77,7 +77,7 @@
       :vault-name="vaultName"
     />
     <!-- List of Credential Details -->
-    <div class="flex flex-col justify-start items-start mt-8 w-full md:mt-2">
+    <div class="mt-8 flex w-full flex-col items-start justify-start md:mt-2">
       <span class="mb-5 text-xl font-bold text-neutrals-dark">{{
         t('CredentialDetails.verifiedInformation')
       }}</span>
@@ -85,17 +85,17 @@
         <tr
           v-for="(property, index) of credential.properties"
           :key="index"
-          class="border-b border-neutrals-thistle border-dotted"
+          class="border-b border-dotted border-neutrals-thistle"
         >
           <!-- TODO: Add the dropdown for the nested credentials 1016 -->
           <td class="py-4 pr-6 pl-3 text-neutrals-medium">{{ property.label }}</td>
           <td
             v-if="property.schema.format === 'image/png'"
-            class="py-4 pr-6 pl-3 text-neutrals-dark break-words"
+            class="break-all py-4 pr-6 pl-3 text-neutrals-dark"
           >
-            <img :src="property.value" class="w-20 h-20" />
+            <img :src="property.value" class="h-20 w-20" />
           </td>
-          <td v-else class="py-4 pr-6 pl-3 text-neutrals-dark break-words">
+          <td v-else class="break-all py-4 pr-6 pl-3 text-neutrals-dark">
             {{ property.value }}
           </td>
         </tr>
@@ -195,13 +195,18 @@ export default {
             this.token,
             decode(this.$route.params.id)
           );
-        this.credential = { id, issuanceDate, name, ...resolved[0] };
+        this.credential = { id, issuanceDate, name: name || resolved[0].title, ...resolved[0] };
       } catch (e) {
         console.error('failed to fetch a credential:', e);
       }
     },
-    handleRenameModalClose: function () {
+    handleRenameModalClose: async function () {
       this.showRenameModal = false;
+      const metadata = await this.credentialManager.getCredentialMetadata(
+        this.token,
+        decode(this.$route.params.id)
+      );
+      this.credential.name = metadata.name;
     },
     handleDeleteModalClose: function () {
       this.showDeleteModal = false;

--- a/cmd/wallet-web/src/pages/CredentialsPage.vue
+++ b/cmd/wallet-web/src/pages/CredentialsPage.vue
@@ -7,23 +7,23 @@
 <template>
   <div>
     <!-- Mobile Credentials Layout -->
-    <div v-if="breakpoints.xs || breakpoints.sm" class="flex flex-col justify-start w-screen">
+    <div v-if="breakpoints.xs || breakpoints.sm" class="flex w-screen flex-col justify-start">
       <SkeletonLoaderComponent v-if="loading" type="Flyout" />
       <FlyoutComponent v-else :tool-tip-label="t('Credentials.switchVaults')">
         <template #button="{ toggleFlyoutMenu, setShowTooltip }">
           <button
             id="credentials-flyout-menu-button-mobile"
-            class="inline-flex justify-between items-center px-3 w-screen h-11 bg-neutrals-white border border-neutrals-chatelle outline-none focus:ring-2 focus:ring-primary-purple focus:ring-opacity-70 focus-within:ring-offset-2 md:w-auto md:rounded-lg hover:border-neutrals-mountainMist-light"
+            class="inline-flex h-11 w-screen items-center justify-between border border-neutrals-chatelle bg-neutrals-white px-3 outline-none focus-within:ring-offset-2 hover:border-neutrals-mountainMist-light focus:ring-2 focus:ring-primary-purple focus:ring-opacity-70 md:w-auto md:rounded-lg"
             @click="toggleFlyoutMenu()"
             @focus="setShowTooltip(false)"
             @mouseover="setShowTooltip(true)"
             @mouseout="setShowTooltip(false)"
           >
-            <img class="w-6 h-6" src="@/assets/img/icons-sm--vault-icon.svg" />
-            <span class="grow pl-2 text-sm font-bold text-left text-neutrals-dark truncate">
+            <img class="h-6 w-6" src="@/assets/img/icons-sm--vault-icon.svg" />
+            <span class="grow truncate pl-2 text-left text-sm font-bold text-neutrals-dark">
               {{ selectedVaultName }}
             </span>
-            <img class="w-6 h-6" src="@/assets/img/icons-sm--chevron-down-icon.svg" />
+            <img class="h-6 w-6" src="@/assets/img/icons-sm--chevron-down-icon.svg" />
           </button>
         </template>
         <template #menu>
@@ -52,7 +52,7 @@
       </div>
     </div>
     <!-- Desktop Credentials Layout -->
-    <div v-else class="flex justify-between items-center mb-8 w-full align-middle">
+    <div v-else class="mb-8 flex w-full items-center justify-between align-middle">
       <div class="flex grow">
         <h3 class="m-0 font-bold text-neutrals-dark">{{ t('Credentials.credentials') }}</h3>
       </div>
@@ -61,17 +61,17 @@
         <template #button="{ toggleFlyoutMenu, setShowTooltip }">
           <button
             id="credentials-flyout-menu-button-desktop"
-            class="inline-flex justify-between items-center px-3 w-screen h-11 bg-neutrals-white border border-neutrals-chatelle outline-none focus:ring-2 focus:ring-primary-purple focus:ring-opacity-70 focus-within:ring-offset-2 md:w-auto md:rounded-lg hover:border-neutrals-mountainMist-light"
+            class="inline-flex h-11 w-screen items-center justify-between border border-neutrals-chatelle bg-neutrals-white px-3 outline-none focus-within:ring-offset-2 hover:border-neutrals-mountainMist-light focus:ring-2 focus:ring-primary-purple focus:ring-opacity-70 md:w-auto md:rounded-lg"
             @click="toggleFlyoutMenu()"
             @focus="setShowTooltip(false)"
             @mouseover="setShowTooltip(true)"
             @mouseout="setShowTooltip(false)"
           >
-            <img class="w-6 h-6" src="@/assets/img/icons-sm--vault-icon.svg" />
-            <span class="grow pl-2 text-sm font-bold text-left text-neutrals-dark truncate">
+            <img class="h-6 w-6" src="@/assets/img/icons-sm--vault-icon.svg" />
+            <span class="grow truncate pl-2 text-left text-sm font-bold text-neutrals-dark">
               {{ selectedVaultName }}
             </span>
-            <img class="w-6 h-6" src="@/assets/img/icons-sm--chevron-down-icon.svg" />
+            <img class="h-6 w-6" src="@/assets/img/icons-sm--chevron-down-icon.svg" />
           </button>
         </template>
         <template #menu="{ toggleFlyoutMenu }">
@@ -122,7 +122,7 @@
             <div class="mb-5 md:mx-0">
               <span class="text-xl font-bold text-neutrals-dark">{{ vault.name }}</span>
             </div>
-            <ul class="grid grid-cols-1 gap-4 my-8 xl:grid-cols-2 xl:gap-8">
+            <ul class="my-8 grid grid-cols-1 gap-4 xl:grid-cols-2 xl:gap-8">
               <li v-for="(credential, index) in vault.credentials" :key="index">
                 <CredentialPreviewComponent
                   :id="credential.id"
@@ -143,7 +143,7 @@
       </div>
       <div
         v-else
-        class="py-8 px-6 mx-auto rounded-lg border border-neutrals-thistle nocredentialCard"
+        class="nocredentialCard mx-auto rounded-lg border border-neutrals-thistle py-8 px-6"
       >
         <div class="flex justify-center">
           <img src="@/assets/img/icons-md--credentials-icon.svg" />
@@ -233,7 +233,7 @@ export default {
         });
         return metadataList.map((credential) => ({
           id: encode(credential.id),
-          name: credential.name,
+          name: credential.name || credential.resolved[0].title,
           ...credential.resolved[0],
         }));
       } catch (e) {

--- a/cmd/wallet-web/src/pages/OIDCSharePage.vue
+++ b/cmd/wallet-web/src/pages/OIDCSharePage.vue
@@ -5,7 +5,7 @@
 -->
 
 <template>
-  <div v-if="!showMainState" class="flex flex-col grow justify-center items-center w-full h-full">
+  <div v-if="!showMainState" class="flex h-full w-full grow flex-col items-center justify-center">
     <!-- Loading State -->
     <WACILoadingComponent v-if="loading" />
 
@@ -23,27 +23,27 @@
   </div>
 
   <!-- Main State -->
-  <div v-else class="flex overflow-hidden flex-col grow justify-between items-center w-full h-full">
-    <div class="flex overflow-auto justify-center w-full">
+  <div v-else class="flex h-full w-full grow flex-col items-center justify-between overflow-hidden">
+    <div class="flex w-full justify-center overflow-auto">
       <div
-        class="flex flex-col grow justify-start items-start py-8 px-5 w-full max-w-3xl h-full md:px-0"
+        class="flex h-full w-full max-w-3xl grow flex-col items-start justify-start py-8 px-5 md:px-0"
       >
         <span class="mb-6 text-3xl font-bold">{{
           t('CHAPI.Share.shareCredential', processedCredentials.length)
         }}</span>
-        <div class="flex flex-row justify-start items-start mb-4 w-full">
-          <div class="flex-none w-12 h-12 border-opacity-10">
+        <div class="mb-4 flex w-full flex-row items-start justify-start">
+          <div class="h-12 w-12 flex-none border-opacity-10">
             <!-- todo issue-1055 Read meta data from external urls -->
             <img src="@/assets/img/generic-issuer-icon.svg" />
           </div>
           <div class="flex flex-col pl-3">
-            <span class="flex-1 mb-1 text-sm font-bold text-left text-neutrals-dark text-ellipsis">
+            <span class="mb-1 flex-1 text-ellipsis text-left text-sm font-bold text-neutrals-dark">
               <!-- todo issue-1055 Read meta data from external urls -->
               Requestor
             </span>
-            <div class="flex flex-row justify-center items-center">
+            <div class="flex flex-row items-center justify-center">
               <img src="@/assets/img/small-lock-icon.svg" />
-              <span class="flex-1 pl-1 text-xs text-left text-neutrals-medium text-ellipsis">
+              <span class="flex-1 text-ellipsis pl-1 text-left text-xs text-neutrals-medium">
                 {{ requestOrigin }}
               </span>
             </div>
@@ -57,17 +57,17 @@
         <!-- Single Credential Overview (with details) -->
         <CredentialOverviewComponent
           v-if="processedCredentials.length === 1"
-          class="my-5 waci-share-credential-overview-root"
+          class="waci-share-credential-overview-root my-5"
           :credential="processedCredentials[0]"
         >
           <template #bannerBottomContainer>
             <div
-              class="flex absolute flex-row justify-start items-start px-5 pt-13 pb-3 w-full bg-neutrals-white rounded-b-xl waci-share-credential-overview-vault"
+              class="waci-share-credential-overview-vault absolute flex w-full flex-row items-start justify-start rounded-b-xl bg-neutrals-white px-5 pt-13 pb-3"
             >
               <span class="flex text-sm font-bold text-neutrals-dark">
                 {{ t('CredentialDetails.Banner.vault') }}
               </span>
-              <span class="flex ml-3 text-sm text-neutrals-medium">
+              <span class="ml-3 flex text-sm text-neutrals-medium">
                 {{ processedCredentials[0].vaultName }}
               </span>
             </div>
@@ -81,7 +81,7 @@
         </CredentialOverviewComponent>
 
         <!-- List of Credential Banners (Links to Details for each) -->
-        <ul v-else-if="processedCredentials.length > 1" class="mt-6 space-y-5 w-full">
+        <ul v-else-if="processedCredentials.length > 1" class="mt-6 w-full space-y-5">
           <li v-for="(credential, index) in processedCredentials" :key="index">
             <CredentialBannerComponent
               :id="credential.id"
@@ -230,7 +230,13 @@ export default {
           const {
             content: { name: vaultName },
           } = await this.collectionManager.get(this.token, collection);
-          this.processedCredentials.push({ id, name, issuanceDate, ...resolved[0], vaultName });
+          this.processedCredentials.push({
+            id,
+            name: name || resolved[0].title,
+            issuanceDate,
+            ...resolved[0],
+            vaultName,
+          });
         });
       } catch (e) {
         this.errors.push('No credentials found matching requested criteria.');

--- a/cmd/wallet-web/src/pages/WACISharePage.vue
+++ b/cmd/wallet-web/src/pages/WACISharePage.vue
@@ -5,7 +5,7 @@
 -->
 
 <template>
-  <div v-if="!showMainState" class="flex flex-col grow justify-center items-center w-full h-full">
+  <div v-if="!showMainState" class="flex h-full w-full grow flex-col items-center justify-center">
     <!-- Loading State -->
     <WACILoadingComponent v-if="loading" />
 
@@ -46,27 +46,27 @@
   </div>
 
   <!-- Main State -->
-  <div v-else class="flex overflow-hidden flex-col grow justify-between items-center w-full h-full">
-    <div class="flex overflow-auto justify-center w-full">
+  <div v-else class="flex h-full w-full grow flex-col items-center justify-between overflow-hidden">
+    <div class="flex w-full justify-center overflow-auto">
       <div
-        class="flex flex-col grow justify-start items-start py-8 px-5 w-full max-w-3xl h-full md:px-0"
+        class="flex h-full w-full max-w-3xl grow flex-col items-start justify-start py-8 px-5 md:px-0"
       >
         <span class="mb-6 text-3xl font-bold">{{
           t('CHAPI.Share.shareCredential', processedCredentials.length)
         }}</span>
-        <div class="flex flex-row justify-start items-start mb-4 w-full">
-          <div class="flex-none w-12 h-12 border-opacity-10">
+        <div class="mb-4 flex w-full flex-row items-start justify-start">
+          <div class="h-12 w-12 flex-none border-opacity-10">
             <!-- todo issue-1055 Read meta data from external urls -->
             <img src="@/assets/img/generic-issuer-icon.svg" />
           </div>
           <div class="flex flex-col pl-3">
-            <span class="flex-1 mb-1 text-sm font-bold text-left text-neutrals-dark text-ellipsis">
+            <span class="mb-1 flex-1 text-ellipsis text-left text-sm font-bold text-neutrals-dark">
               <!-- todo issue-1055 Read meta data from external urls -->
               Requestor
             </span>
-            <div class="flex flex-row justify-center items-center">
+            <div class="flex flex-row items-center justify-center">
               <img src="@/assets/img/small-lock-icon.svg" />
-              <span class="flex-1 pl-1 text-xs text-left text-neutrals-medium text-ellipsis">
+              <span class="flex-1 text-ellipsis pl-1 text-left text-xs text-neutrals-medium">
                 {{ requestOrigin }}
               </span>
             </div>
@@ -80,17 +80,17 @@
         <!-- Single Credential Overview (with details) -->
         <CredentialOverviewComponent
           v-if="processedCredentials.length === 1"
-          class="my-5 waci-share-credential-overview-root"
+          class="waci-share-credential-overview-root my-5"
           :credential="processedCredentials[0]"
         >
           <template #bannerBottomContainer>
             <div
-              class="flex absolute flex-row justify-start items-start px-5 pt-13 pb-3 w-full bg-neutrals-white rounded-b-xl waci-share-credential-overview-vault"
+              class="waci-share-credential-overview-vault absolute flex w-full flex-row items-start justify-start rounded-b-xl bg-neutrals-white px-5 pt-13 pb-3"
             >
               <span class="flex text-sm font-bold text-neutrals-dark">
                 {{ t('CredentialDetails.Banner.vault') }}
               </span>
-              <span class="flex ml-3 text-sm text-neutrals-medium">
+              <span class="ml-3 flex text-sm text-neutrals-medium">
                 {{ processedCredentials[0].vaultName }}
               </span>
             </div>
@@ -104,7 +104,7 @@
         </CredentialOverviewComponent>
 
         <!-- List of Credential Banners (Links to Details for each) -->
-        <ul v-else-if="processedCredentials.length > 1" class="mt-6 space-y-5 w-full">
+        <ul v-else-if="processedCredentials.length > 1" class="mt-6 w-full space-y-5">
           <li v-for="(credential, index) in processedCredentials" :key="index">
             <CredentialBannerComponent
               :id="credential.id"
@@ -238,7 +238,13 @@ export default {
           const {
             content: { name: vaultName },
           } = await this.collectionManager.get(this.token, collection);
-          this.processedCredentials.push({ id, name, issuanceDate, ...resolved[0], vaultName });
+          this.processedCredentials.push({
+            id,
+            name: name || resolved[0].title,
+            issuanceDate,
+            ...resolved[0],
+            vaultName,
+          });
         });
       } catch (e) {
         this.errors.push('No credentials found matching requested criteria.');


### PR DESCRIPTION
Closes #1824 
What's changed:
If the 'credential name' property in a vc is empty, use the title from the credential manifest (returned from resolveManifest) instead - this is in [CredentialDetailsPage](https://github.com/trustbloc/wallet/compare/main...HeidiHan0000:wallet:issue-1824?expand=1#diff-936eaa2bc7316c5c0a24b5d06f8fc304526a63a985db8a470a46a7a8d11baa0dR197), [CredentialsPage](https://github.com/trustbloc/wallet/compare/main...HeidiHan0000:wallet:issue-1824?expand=1#diff-31f5afb2683cbf248197fb5dcf47321325ee209c4ab8cb27f5762017253c1905R236), [OIDCSharePage](https://github.com/trustbloc/wallet/compare/main...HeidiHan0000:wallet:issue-1824?expand=1#diff-c2fd5c10cf3198ca1ce1bd4a62ba8e5442d9bb5470fd409d31b42bc02b231cdcR230), and [WACISharePage](https://github.com/trustbloc/wallet/compare/main...HeidiHan0000:wallet:issue-1824?expand=1#diff-6b515f1481bd545edb0b9b2d62035d45010f689d1772224abf184f4c7e3185e4R238) (the rest of the changes are from linting). 

Name is an optional property in vc (id and issuanceDate are required fields), so if it is empty, it should get its value from credential manifest. (If it isn't empty, continue using the name from the vc because user may have changed the name of the vc). The case where the credential manifest is missing the title (equivalent of name property) and needs to get data from [credential-output-descriptors.json](https://github.com/trustbloc/wallet/blob/main/cmd/wallet-web/src/config/credential-output-descriptors.json#L2) like mentioned on the issue will be covered in #1832 


Signed-off-by: heidihan0000 <daeun.han@avast.com>