### PR TITLE
feat: added check for empty optional properties for resolveManifest

### DIFF
--- a/cmd/wallet-web/src/pages/CHAPISharePage.vue
+++ b/cmd/wallet-web/src/pages/CHAPISharePage.vue
@@ -12,6 +12,7 @@ import {
   getCredentialIcon,
   WalletGetByQuery,
   prepareCredentialManifest,
+  resolveManifest,
 } from '@/mixins';
 import SpinnerIcon from '@/components/icons/SpinnerIcon.vue';
 import { useI18n } from 'vue-i18n';
@@ -71,7 +72,7 @@ onMounted(async () => {
     credentialManifests.value,
     requestOrigin.value
   );
-  credsFound.value = await credentialManager.resolveManifest(token, {
+  credsFound.value = await resolveManifest(credentialManager, token, {
     manifest,
     fulfillment: presentation.value,
   });

--- a/cmd/wallet-web/src/pages/MultipleQueryPage.vue
+++ b/cmd/wallet-web/src/pages/MultipleQueryPage.vue
@@ -191,7 +191,12 @@
 <script>
 import { toRaw } from 'vue';
 import { CredentialManager } from '@trustbloc/wallet-sdk';
-import { normalizeQuery, getCredentialIcon, prepareCredentialManifest } from '@/mixins';
+import {
+  normalizeQuery,
+  getCredentialIcon,
+  prepareCredentialManifest,
+  resolveManifest,
+} from '@/mixins';
 import { mapGetters } from 'vuex';
 import SpinnerIcon from '@/components/icons/SpinnerIcon.vue';
 import { useI18n } from 'vue-i18n';
@@ -235,7 +240,7 @@ export default {
         this.getCredentialManifests(),
         this.protocolHandler.requestor()
       );
-      this.processedCredentials = await this.credentialManager.resolveManifest(this.token, {
+      this.processedCredentials = await resolveManifest(this.credentialManager, this.token, {
         manifest,
         fulfillment: this.presentation[0],
       });

--- a/cmd/wallet-web/src/pages/OIDCSavePage.vue
+++ b/cmd/wallet-web/src/pages/OIDCSavePage.vue
@@ -98,7 +98,12 @@ import WACIErrorComponent from '@/components/WACI/WACIErrorComponent.vue';
 import WACILoadingComponent from '@/components/WACI/WACILoadingComponent.vue';
 import WACISuccessComponent from '@/components/WACI/WACISuccessComponent.vue';
 import CredentialDetailsTableComponent from '@/components/WACI/CredentialDetailsTableComponent.vue';
-import { readOpenIDConfiguration, requestCredential, requestToken } from '@/mixins';
+import {
+  readOpenIDConfiguration,
+  requestCredential,
+  requestToken,
+  resolveManifest,
+} from '@/mixins';
 import Cookies from 'js-cookie';
 import jp from 'jsonpath';
 
@@ -258,12 +263,11 @@ export default {
         throw 'unable to find matching manifest'; // TODO handle this error, Issue #1531
       }
 
-      const processed = await this.credentialManager.resolveManifest(this.token, {
+      const processed = await resolveManifest(this.credentialManager, this.token, {
         credential,
         manifest,
         descriptorID,
       });
-
       return { processed, descriptorID, manifest };
     },
   },

--- a/cmd/wallet-web/src/pages/StorePage.vue
+++ b/cmd/wallet-web/src/pages/StorePage.vue
@@ -106,6 +106,7 @@ import {
   getCredentialIcon,
   isVPType,
   prepareCredentialManifest,
+  resolveManifest,
 } from '@/mixins';
 import { CollectionManager, CredentialManager } from '@trustbloc/wallet-sdk';
 import { mapGetters } from 'vuex';
@@ -170,7 +171,7 @@ export default {
       credential.showDetails = !credential.showDetails;
     },
     fetchCredentials: async function () {
-      this.processedCredentials = await this.credentialManager.resolveManifest(this.token, {
+      this.processedCredentials = await resolveManifest(this.credentialManager, this.token, {
         manifest: this.manifest,
         fulfillment: this.presentation,
       });

--- a/cmd/wallet-web/src/pages/WACIIssuePage.vue
+++ b/cmd/wallet-web/src/pages/WACIIssuePage.vue
@@ -89,6 +89,7 @@ import { mapGetters } from 'vuex';
 import { CollectionManager, CredentialManager, DIDComm } from '@trustbloc/wallet-sdk';
 import { useI18n } from 'vue-i18n';
 import { WACIStore } from '@/layouts/WACILayout.vue';
+import { resolveManifest } from '@/mixins';
 import CustomSelectComponent from '@/components/CustomSelect/CustomSelectComponent.vue';
 import StyledButtonComponent from '@/components/StyledButton/StyledButtonComponent.vue';
 import CredentialOverviewComponent from '@/components/WACI/CredentialOverviewComponent.vue';
@@ -178,7 +179,7 @@ export default {
     ...mapGetters('agent', { getAgentInstance: 'getInstance' }),
     prepareCards: async function () {
       const { fulfillment, manifest } = this.interactionData;
-      this.processedCredentials = await this.credentialManager.resolveManifest(this.token, {
+      this.processedCredentials = await resolveManifest(this.credentialManager, this.token, {
         manifest,
         fulfillment,
       });


### PR DESCRIPTION
Closes #1832 
Added check for empty optional fields in the manifest before it gets resolved by `resolveManifest`. These are fields that are required by the wallet to display the credential properly but are not required in the credential manifest as per the [specs](https://identity.foundation/wallet-rendering/v0.0.1/#entity-styles) (ex. credential name, background colour, etc...).  
Signed-off-by: heidihan0000 <daeun.han@avast.com>