### PR TITLE
fix: sandbox issue with credential manifests

### DIFF
--- a/cmd/wallet-web/package-lock.json
+++ b/cmd/wallet-web/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "wallet-web",
       "version": "0.1.0",
       "dependencies": {
         "@trustbloc-cicd/agent-sdk-web": "0.1.9-snapshot-2cc554f",

--- a/cmd/wallet-web/src/config/credential-output-descriptors.json
+++ b/cmd/wallet-web/src/config/credential-output-descriptors.json
@@ -536,7 +536,10 @@
               }
             },
             "description": {
-              "text": ""
+              "path": ["$.description"],
+              "schema": {
+                "type": "string"
+              }
             },
             "properties": []
           },

--- a/cmd/wallet-web/src/pages/CHAPISharePage.vue
+++ b/cmd/wallet-web/src/pages/CHAPISharePage.vue
@@ -72,7 +72,7 @@ onMounted(async () => {
     credentialManifests.value,
     requestOrigin.value
   );
-  credsFound.value = await resolveManifest(credentialManager, token, {
+  credsFound.value = await resolveManifest(credentialManager, credentialManifests.value, token, {
     manifest,
     fulfillment: presentation.value,
   });

--- a/cmd/wallet-web/src/pages/MultipleQueryPage.vue
+++ b/cmd/wallet-web/src/pages/MultipleQueryPage.vue
@@ -240,10 +240,15 @@ export default {
         this.getCredentialManifests(),
         this.protocolHandler.requestor()
       );
-      this.processedCredentials = await resolveManifest(this.credentialManager, this.token, {
-        manifest,
-        fulfillment: this.presentation[0],
-      });
+      this.processedCredentials = await resolveManifest(
+        this.credentialManager,
+        this.getCredentialManifests(),
+        this.token,
+        {
+          manifest,
+          fulfillment: this.presentation[0],
+        }
+      );
     } catch (e) {
       this.errors.push(e);
       console.error('get credentials failed,', e);

--- a/cmd/wallet-web/src/pages/OIDCSavePage.vue
+++ b/cmd/wallet-web/src/pages/OIDCSavePage.vue
@@ -196,7 +196,7 @@ export default {
     this.loading = false;
   },
   methods: {
-    ...mapGetters(['getCurrentUser']),
+    ...mapGetters(['getCurrentUser', 'getCredentialManifests']),
     ...mapGetters('agent', { getAgentInstance: 'getInstance' }),
     save: function () {
       this.errors.length = 0;
@@ -263,11 +263,16 @@ export default {
         throw 'unable to find matching manifest'; // TODO handle this error, Issue #1531
       }
 
-      const processed = await resolveManifest(this.credentialManager, this.token, {
-        credential,
-        manifest,
-        descriptorID,
-      });
+      const processed = await resolveManifest(
+        this.credentialManager,
+        this.getCredentialManifests(),
+        this.token,
+        {
+          credential,
+          manifest,
+          descriptorID,
+        }
+      );
       return { processed, descriptorID, manifest };
     },
   },

--- a/cmd/wallet-web/src/pages/StorePage.vue
+++ b/cmd/wallet-web/src/pages/StorePage.vue
@@ -171,10 +171,15 @@ export default {
       credential.showDetails = !credential.showDetails;
     },
     fetchCredentials: async function () {
-      this.processedCredentials = await resolveManifest(this.credentialManager, this.token, {
-        manifest: this.manifest,
-        fulfillment: this.presentation,
-      });
+      this.processedCredentials = await resolveManifest(
+        this.credentialManager,
+        this.getCredentialManifests(),
+        this.token,
+        {
+          manifest: this.manifest,
+          fulfillment: this.presentation,
+        }
+      );
       if (this.processedCredentials.length === 1) this.processedCredentials[0].showDetails = true;
     },
     fetchVaults: async function (token, collectionManager) {

--- a/cmd/wallet-web/src/pages/WACIIssuePage.vue
+++ b/cmd/wallet-web/src/pages/WACIIssuePage.vue
@@ -175,14 +175,19 @@ export default {
     this.loading = false;
   },
   methods: {
-    ...mapGetters(['getCurrentUser']),
+    ...mapGetters(['getCurrentUser', 'getCredentialManifests']),
     ...mapGetters('agent', { getAgentInstance: 'getInstance' }),
     prepareCards: async function () {
       const { fulfillment, manifest } = this.interactionData;
-      this.processedCredentials = await resolveManifest(this.credentialManager, this.token, {
-        manifest,
-        fulfillment,
-      });
+      this.processedCredentials = await resolveManifest(
+        this.credentialManager,
+        this.getCredentialManifests(),
+        this.token,
+        {
+          manifest,
+          fulfillment,
+        }
+      );
     },
     save: async function () {
       this.errors.length = 0;

--- a/cmd/wallet-web/test/fixtures/testdata/credential-output-descriptors.json
+++ b/cmd/wallet-web/test/fixtures/testdata/credential-output-descriptors.json
@@ -183,7 +183,10 @@
               }
             },
             "description": {
-              "text": ""
+              "path": ["$.description"],
+              "schema": {
+                "type": "string"
+              }
             },
             "properties": []
           },

--- a/test/fixtures/wallet-web/static/config/credential-output-descriptors.json
+++ b/test/fixtures/wallet-web/static/config/credential-output-descriptors.json
@@ -538,7 +538,10 @@
               }
             },
             "description": {
-              "text": ""
+              "path": ["$.description"],
+              "schema": {
+                "type": "string"
+              }
             },
             "properties": []
           },


### PR DESCRIPTION
Closes https://github.com/trustbloc/sandbox/issues/1500 
Changes:
- added description property to the default `VerifiableCredential` in credential-output-descriptors.json
- use the default 'VerifiableCredential' output descriptor if default output descriptor for a certain credential does not exist

Signed-off-by: heidihan0000 <daeun.han@avast.com>