### PR TITLE
test: added test case for missing default manifest in wallet + resolveManifest changes

### DIFF
--- a/test/ui-automation/test/specs/credential-interaction-flow.js
+++ b/test/ui-automation/test/specs/credential-interaction-flow.js
@@ -234,6 +234,58 @@ credential.set("BookingReference", {
     },
   },
 });
+credential.set("GovernanceCredential", {
+  name: "Governance Credential",
+  vc: {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://trustbloc.github.io/context/governance/context.jsonld",
+      "https://w3id.org/vc-revocation-list-2020/v1",
+    ],
+    credentialSubject: {
+      description: "Sample governance framework for the TrustBloc sandbox.",
+      geos: "Canadian",
+      jurisdictions: "ca",
+      roles: "accreditor",
+      topics: "banking",
+      version: "1.0",
+    },
+    id: "https://example.com/governance",
+    issuanceDate: "2021-07-06T17:20:57.736460722Z",
+    issuer: "did:orb:interim:EiAbjeimRkgIIswIPpHpWO3JeXZg3eeuVjlzzCeAjgOC-g",
+    name: "Governance Credential",
+    proof: {
+      created: "2021-07-06T17:20:57.851590383Z",
+      jws: "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..92EdftDqyPKq4HYjjwRrtYPUBVWukVxbhweNvque-QfMSkL7FKww-5Q25hq5uowa-6mFiV3UvB-9xC2x5s-eCg",
+      proofPurpose: "assertionMethod",
+      type: "Ed25519Signature2018",
+      verificationMethod:
+        "did:orb:interim:EiAbjeimRkgIIswIPpHpWO3JeXZg3eeuVjlzzCeAjgOC-g#a5hRq_BgA-TU0-RUsuhoIo3qQhrTEt2iKO9MPDeZ2fc",
+    },
+    type: ["VerifiableCredential", "GovernanceCredential"],
+  },
+  vcSubjectData: [
+    { name: "Description", value: "Sample governance framework" },
+    { name: "Geos", value: "Canadian" },
+    { name: "Jurisdictions", value: "ca" },
+    { name: "Roles", value: "accreditor" },
+    { name: "Topics", value: "banking" },
+    { name: "Version", value: "1.0" },
+  ],
+  vpRequest: {
+    type: "QueryByExample",
+    credentialQuery: {
+      reason: "Please present your Governance Credential.",
+      example: {
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://trustbloc.github.io/context/governance/context.jsonld",
+        ],
+        type: ["GovernanceCredential"],
+      },
+    },
+  },
+});
 
 describe("TrustBloc Wallet - Store/Share credential flow (CHAPI)", () => {
   const ctx = {


### PR DESCRIPTION
Closes #1854 
- Added test case for issuing a VC for which wallet does not have default output descriptors for in https://github.com/trustbloc/wallet/blob/main/cmd/wallet-web/src/config/credential-output-descriptors.json
- Changes to resolveManifest:
  - For the above case, `display.properties` were loaded into the credential manifest from the `credentialSubject` field of the VC only for CHAPI store - added the same steps for loading `display.properties` to `resolveManifest` so that the Verified Information properties would be displayed also for the WACI and OIDC issuance flows
  - If `display.properties` were loaded from `credentialSubject`, capitalize first letter of the label

. | Before | After
| --- | --- | ---
WACI | <img width="400" alt="Screen Shot 2022-08-23 at 8 51 14 AM" src="https://user-images.githubusercontent.com/44453261/186162459-e33e5b69-d2c2-4844-b6a7-79c9e29a2dc9.png"> | <img width="400" alt="Screen Shot 2022-08-23 at 8 40 30 AM" src="https://user-images.githubusercontent.com/44453261/186160490-f05243fb-7ad6-405e-a60d-6aba06154d76.png">
CHAPI | <img width="400" alt="chapibefore" src="https://user-images.githubusercontent.com/44453261/186159239-fa20cb5b-9268-441b-9a86-9881860f644c.png">| <img width="300" alt="after" src="https://user-images.githubusercontent.com/44453261/186160462-2f19da41-8485-48d0-a9d0-d3f6b23d9882.png"> 





Signed-off-by: heidihan0000 daeun.han@avast.com